### PR TITLE
UHF-X: Add email case for form element type

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -127,9 +127,10 @@ function hdbt_preprocess_form_element(&$variables) {
         $element_label_class = 'hds-radio-button__label';
         break;
 
-      case 'textfield':
+      case 'email':
       case 'password':
       case 'textarea':
+      case 'textfield':
         $element_label_class = 'hds-text-input__label';
         break;
     }


### PR DESCRIPTION
1. `make fresh`
2. Make sure that email form field labels get hds classes and have the same styles as other form field labels.