### PR TITLE
UHF-1473: Thumbnail alts

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -217,6 +217,8 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $variables['accordion_heading_level'] = $accordion_heading_level;
   }
 
+  // Check if the paragraph is a type of gallery and prepare the slides
+  // and generate the thumbnails.
   if ($paragraph_type == 'gallery') {
     $variables['#attached']['library'][] = 'hdbt/gallery';
 
@@ -233,6 +235,7 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $slides = $paragraph_storage->loadMultiple($slide_ids);
 
     $slide_thumbnails = [];
+    $slide_thumbnails_alternative_texts = [];
     foreach ($slides as $slide) {
       $slide_media = $slide
         ->get('field_gallery_slide_media')
@@ -246,10 +249,18 @@ function hdbt_preprocess_paragraph(array &$variables) {
         ->get('entity')
         ->getTarget()
         ->getValue();
+
+      $alternative_text = [
+        'caption' => $slide->field_gallery_slide_caption->value,
+        'alt' => $slide_media->field_media_image->first()->alt,
+      ];
+
+      $slide_thumbnails_alternative_texts[] = $alternative_text;
       $slide_thumbnails[] = $image;
     }
 
     $variables['gallery_slide_thumbnails'] = $slide_thumbnails;
+    $variables['gallery_slide_thumbnails_alt_texts'] = $slide_thumbnails_alternative_texts;
   }
 
   // Unit search paragraph.

--- a/templates/paragraphs/paragraph--gallery.html.twig
+++ b/templates/paragraphs/paragraph--gallery.html.twig
@@ -46,7 +46,7 @@
 %}
 
 {% block paragraph %}
-  <div{{ attributes.addClass(classes).setAttribute('aria-hidden', 'true') }}>
+  <div{{ attributes.addClass(classes).setAttribute('aria-hidden', 'true').setAttribute('aria-label', 'Image gallery'|t) }}>
     {% embed "@hdbt/misc/container.twig" with {container_element: 'gallery'} %}
       {% block container_content %}
         <div class="gallery__main splide">
@@ -60,9 +60,18 @@
         <div class="gallery__thumbnails js-gallery__thumbnails">
           <ul class="gallery__thumbnails__list">
             {% for key, image in gallery_slide_thumbnails %}
-              {% set alt = image.alt %}
-              <li class="gallery__thumbnails__item" role="button" tabindex="0">
-                {{ drupal_image(image.uri.value, 'gallery_thumbnail', {alt: alt}, responsive=true) }}
+              {% set gallery_thumbnails_item = create_attribute({'class': 'gallery__thumbnails__item'}).setAttribute('role', 'button').setAttribute('tabindex', '0') %}
+              {% if gallery_slide_thumbnails_alt_texts[key].caption %}
+                {% set alt = gallery_slide_thumbnails_alt_texts[key].caption %}
+                {% set gallery_thumbnails_item = gallery_thumbnails_item.setAttribute('aria-label', gallery_slide_thumbnails_alt_texts[key].caption) %}
+              {% elseif gallery_slide_thumbnails_alt_texts[key].alt is not same as('""') %}
+                {% set alt = gallery_slide_thumbnails_alt_texts[key].alt %}
+                {% set gallery_thumbnails_item = gallery_thumbnails_item.setAttribute('aria-label', gallery_slide_thumbnails_alt_texts[key].alt) %}
+              {% else %}
+                {% set alt = false %}
+              {% endif %}
+              <li{{ gallery_thumbnails_item }}>
+                {{ drupal_image(image.uri.value, 'gallery_thumbnail', { alt: alt }, responsive=true) }}
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
How to test: 
- Checkout this branch and go to https://helfi.docker.sh/fi/esimerkkisivu and check that the gallery thumbnails have alt texts