### PR TITLE
UHF-X: Add sourcemaps to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/icons/hds
 # Other
 .DS_Store
 .idea
+dist/**/*.map


### PR DESCRIPTION
Since we have generated code in repo, we tend to get these dangling files of sourcemaps in dist folder. They're not added to repository as we build to prod instead of dev before deploying. However, they get left behind when changing branch and mark the folder as dirty as they do so.

That's why I added sourcemaps to .gitignore.

How to test
1. Run `npm run dev`, once compiled, exit from if and checkout the latest from git `git checkout .`. Notice the sourcemaps being left behind with `git status`.
2. On project root run `composer require drupal/hdbt:dev-UHF-X_add_source_maps_to_gitignore`
3. Run the same tests again from step 1. Notice the sourcemaps no longer being listed with `git status`.