### PR TITLE
UHF-2673: Add template for Kuura health chat so that the ID of the bl…

### DIFF
--- a/templates/block/block--kuura-health-chat.html.twig
+++ b/templates/block/block--kuura-health-chat.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.setAttribute('id', 'block-kuurahealthchat') }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>


### PR DESCRIPTION
…ock is always the correct one

How to test:

1. Test using sote instance. On the instance root run `composer require drupal/hdbt:dev-UHF-2673_fix_kuura_health_chat_block_wrapper`
2. `make drush-cr`
3. Go to front page of the instance and you should see the Kuura Health Chat again that was missing.