### PR TITLE
UHF-2720: Breadcrumb fix - Prevent error on any page with a sidebar menu

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Url;
 use Drupal\helfi_tpr\Entity\ErrandService;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -325,6 +326,19 @@ function hdbt_preprocess_block(&$variables) {
             'url' => $parent_item->getUrlObject(),
           ];
         }
+      }
+      else {
+        $front_page = Url::fromRoute('<front>', [], ['absolute' => TRUE]);
+        $uri_parts = parse_url($front_page->toString());
+        $url = Url::fromUri('internal:' . $uri_parts['path']);
+        $params = $url->getRouteParameters();
+        $entity_type = key($params);
+        $node = \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
+
+        $variables['menu_link_parent'] = [
+          'title' => $node->getTitle(),
+          'url' => $node->toUrl('canonical', ['absolute' => TRUE])->toString(),
+        ];
       }
     }
   }


### PR DESCRIPTION
In some cases with pages with a sidebar, sidebar parent menu link could not be found and site crashed. Added fallback link to front-page. Must be merged before the breadcrumb fix. 

Use any existing site
Run `composer require drupal/helfi_hdbt:dev-UHF-2720_breadcrumb_fix`
Run `drush cr`
Modify the menu: 
- Move all existing second level links to first level. 
- Save the menu
- Remove the original first level link.
- Save the menu
- Set the sidebar main menu and main navigation menu "initial visibility level" from 2 to 1
/admin/structure/block/manage/mainnavigation,
/admin/structure/block/manage/main_navigation_level_2
- Switch system site settings "front page" to `/node/1`

Go to any page with a sidebar. You should see:
- Sidebar menu title as front page title
- Sidebar menu title link as link to front-page.