### PR TITLE
UHF-3239: Missing sidebar

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -13,7 +13,6 @@ use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Url;
 use Drupal\helfi_tpr\Entity\ErrandService;
 use Drupal\node\Entity\Node;
-use Drupal\node\NodeInterface;
 use Drupal\Core\Site\Settings;
 
 /**

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -186,22 +186,6 @@ function hdbt_preprocess_page(&$variables) {
   if ($data = hdbt_get_settings('footer_color', 'footer_settings')) {
     $variables['page']['footer_color'] = $data;
   }
-
-  // If we're handling page which is in menu, set variable accordingly.
-  if (
-    isset($variables['node']) &&
-    $variables['node'] instanceof NodeInterface &&
-    $variables['node']->getType() == 'page'
-  ) {
-    $defaults = menu_ui_get_menu_link_defaults($variables['node']);
-    if ($defaults['id']) {
-      $variables['has_navigation'] = TRUE;
-    }
-
-    if ($variables['node']->hasField('field_has_hero')) {
-      $variables['has_hero'] = $variables['node']->field_has_hero->value;
-    }
-  }
 }
 
 /**

--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -271,15 +271,16 @@ function hdbt_content_preprocess_page(&$variables) {
     if (!empty($menu_links) && is_array($menu_links)) {
       $menu_Link = reset($menu_links);
 
-      // Set page_has_sidebar value true, if menu link is enabled and it has parent.
+      // Set page_has_sidebar value true,
+      // if menu link is enabled and it has parent.
       if ($menu_Link->isEnabled() && $menu_Link->getParent()) {
         $variables['page_has_sidebar'] = TRUE;
         return;
       }
     }
 
-    // Set page_has_sidebar value ture, if page entity has sidebar content field
-    // and it is not empty.
+    // Set page_has_sidebar value true,
+    // if page entity has sidebar content field and it is not empty.
     if (
       $page_entity->hasField('field_sidebar_content') &&
       !$page_entity->get('field_sidebar_content')->isEmpty()) {

--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\block\Entity\Block;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_theme().
@@ -261,6 +262,11 @@ function hdbt_content_preprocess_page(&$variables) {
   // Check if the current page entity is content entity.
   if (!empty($page_entity) && $page_entity instanceof ContentEntityInterface) {
 
+    // Set has_hero variable according to field_has_hero.
+    if ($page_entity->hasField('field_has_hero')) {
+      $variables['has_hero'] = $page_entity->field_has_hero->value;
+    }
+
     // Load menu links for the current page entity.
     $menu_links = $menu_link_manager->loadLinksByRoute(
       "entity.{$page_entity->getEntityTypeId()}.canonical",
@@ -275,6 +281,7 @@ function hdbt_content_preprocess_page(&$variables) {
       // if menu link is enabled and it has parent.
       if ($menu_Link->isEnabled() && $menu_Link->getParent()) {
         $variables['page_has_sidebar'] = TRUE;
+        $variables['has_navigation'] = TRUE;
         return;
       }
     }

--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -248,3 +248,42 @@ function hdbt_content_block_access(Block $block, $operation, AccountInterface $a
 
   return AccessResult::neutral();
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function hdbt_content_preprocess_page(&$variables) {
+  $variables['page_has_sidebar'] = FALSE;
+
+  $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+  $page_entity = hdbt_content_get_page_entity();
+
+  // Check if the current page entity is content entity.
+  if (!empty($page_entity) && $page_entity instanceof ContentEntityInterface) {
+
+    // Load menu links for the current page entity.
+    $menu_links = $menu_link_manager->loadLinksByRoute(
+      "entity.{$page_entity->getEntityTypeId()}.canonical",
+      [$page_entity->getEntityTypeId() => $page_entity->id()]
+    );
+
+    // Check for menu links.
+    if (!empty($menu_links) && is_array($menu_links)) {
+      $menu_Link = reset($menu_links);
+
+      // Set page_has_sidebar value true, if menu link is enabled and it has parent.
+      if ($menu_Link->isEnabled() && $menu_Link->getParent()) {
+        $variables['page_has_sidebar'] = TRUE;
+        return;
+      }
+    }
+
+    // Set page_has_sidebar value ture, if page entity has sidebar content field
+    // and it is not empty.
+    if (
+      $page_entity->hasField('field_sidebar_content') &&
+      !$page_entity->get('field_sidebar_content')->isEmpty()) {
+      $variables['page_has_sidebar'] = TRUE;
+    }
+  }
+}

--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\block\Entity\Block;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_theme().

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 
-{% if page.sidebar_first|render|striptags|trim is not empty %}
+{% if page_has_sidebar %}
   {% set sidebar_first_output = TRUE %}
 {% endif %}
 
@@ -24,7 +24,6 @@
     has_sidebar ? 'has-sidebar' : 'no-sidebar',
     sidebar_first_output ? 'has-sidebar--first',
     sidebar_second_output ? 'has-sidebar--second',
-
   ]
 %}
 


### PR DESCRIPTION
How to test on any running local instance:
- Run `composer require drupal/hdbt:dev-UHF-3239_missing_sidebar`
- `make drush-cr`
- Check that sidebar is shown for the non super-admin user in basic page