### PR TITLE
UHF-X: Remove duplicate errand service information

### DIFF
--- a/templates/content/tpr-errand-service.html.twig
+++ b/templates/content/tpr-errand-service.html.twig
@@ -48,9 +48,6 @@
                 'component--hardcoded',
                 'errand-service__accordion',
               ],
-              component_title_level: 'h3',
-              component_title: 'Details'|t,
-              component_description: errand_service_details,
               component_content_class: 'accordion',
             }
           %}


### PR DESCRIPTION
To test:

1. Run these on KYMP. It has a visible issue here.
2. `composer require drupal/hdbt:dev-UHF-X_remove_duplicate_errand_service`
3. `make drush-cr`
4. Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pysakointi/asukaspysakointi and make sure the errand service information is written only once on the site.