### PR TITLE
UHF-3552 service channel heading level

### DIFF
--- a/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -23,6 +23,8 @@
 ]
 %}
 
+{% set service_channel_heading_level = service_channel_heading_level|default('h3') %}
+
 <article{{ attributes.addClass(classes) }}>
 
   <div{{ content_attributes.addClass('service-channel__header') }}>
@@ -30,9 +32,9 @@
       {{ content.type_string}}
     </div>
     {% if title_set %}
-      <h2{{ title_attributes.addClass('service-channel__title') }}>
+      <{{ service_channel_heading_level }}{{ title_attributes.addClass('service-channel__title') }}>
         {{ content.name }}
-      </h2>
+      </{{ service_channel_heading_level }}>
     {% endif %}
   </div>
 

--- a/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -1,0 +1,85 @@
+{#
+/**
+ * @file
+ * Template for a TPR Service Channel entity.
+ */
+#}
+
+{% if entity.type.value|lower == 'local' or entity.type.value|lower == 'mail' %}
+  {% set show_mail = true %}
+{% endif %}
+
+{% if content.name|render %}
+  {% set title_set = true %}
+{% endif %}
+
+
+{%
+  set classes = [
+  'service-channel',
+  view_mode ? 'service-channel--' ~ view_mode|clean_class,
+  'service-channel--' ~ entity.type.value|lower,
+  not title_set ? 'service-channel--no-title'
+]
+%}
+
+<article{{ attributes.addClass(classes) }}>
+
+  <div{{ content_attributes.addClass('service-channel__header') }}>
+    <div {{ content_attributes.addClass('service-channel__type') }}>
+      {{ content.type_string}}
+    </div>
+    {% if title_set %}
+      <h2{{ title_attributes.addClass('service-channel__title') }}>
+        {{ content.name }}
+      </h2>
+    {% endif %}
+  </div>
+
+  {% if content.phone|render %}
+    <div class="service-channel__phone">
+      {{ content.phone }}
+    </div>
+  {% endif %}
+
+  {% if entity.requires_authentication.value == 1 or content.availabilities|render %}
+    <div class="service-channel__info">
+      {% if entity.requires_authentication.value == 1 %}
+        <div class="service-channel__requires_authentication">
+          {{ 'Requires authentication'|t }}
+        </div>
+      {% endif %}
+      {% if content.availabilities|render %}
+        <div class="service-channel__availabilities">
+          {{ content.availabilities }}
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if content.email|render %}
+    <div class="service-channel__email">
+      <a href="mailto:{{ content.email.0 }}" class="service-channel__email-link">{{ content.email }}</a>
+    </div>
+  {% endif %}
+
+  {% if content.call_charge_info|render %}
+    <div class="service-channel__call_charge">
+      <span class="service-channel__call_charge-label">{{ 'Call charge'|t }}:</span>
+      {{ content.call_charge_info }}
+    </div>
+  {% endif %}
+
+  {% if show_mail and content.address|render %}
+    <div class="service-channel__address">
+      {{ content.address }}
+    </div>
+  {% endif %}
+
+  {% if content.links|render %}
+    <div class="service-channel__links">
+      {{ content.links }}
+    </div>
+  {% endif %}
+
+</article>


### PR DESCRIPTION
# Service channel heading level
[UHF-3552](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3552)

With the help of the table of contents (ToC) feature , a problem was spotted where service channel headings were set to H2 and became visible in ToC. This caused unwanted repeating of same heading content on identical heading level. 

![image](https://user-images.githubusercontent.com/1191667/144050953-70a88b61-da68-44f9-95d7-faee13ae291f.png)

On SOTE this `h2` level is wanted as there are no previous `h2` headings like in other instances.

## What was done

* The template where this issue is visible was moved to HDBT module for clearer editing in future.
* The template under HDBT now supports custom heading level if set but defaults to `h3`
* Sote has a similarly named template under its `hdbt_subtheme`-theme in similar place to `hdbt`-theme that sets the level to `h2` and then calls the hdbt template
* A notice was added to the original theme in helfi_tpr template as it's being overridden by hdbt now.

## How to test
* Check that the `h2` override works:
  * Get this HDBT branch in your local SOTE instance
  * Get the [sote branch](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/251)
  * Check [a page with service channel](https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/terveysasemat/ehkaisyneuvonta-terveysasemalla) that SOTE has `h2` heading (for example "Asioi Maisassa")
* Check that the `h3` default works:
  * Get this HDBT branch in your local other than SOTE instance, for example KYMP
  * Check [a page with service channel](https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/asukaspysakointi) that instance other than SOTE has `h3` heading (for example "Hanki asukaspysäköintitunnus")
  * Also note that since the service channel headings here are not `h2` anymore, the table of contents looks like this: 
![image](https://user-images.githubusercontent.com/1191667/144050841-e0d5e0ba-207f-4e4d-afae-7ed52439e267.png)
* Check that the [notice in helfi_tpr](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/81/files) is ok and understandable.

Related: [SOTE](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/251), [helfi_tpr](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/81)