### PR TITLE
UHF-3864 Login block for 403 page

### DIFF
--- a/templates/layout/page--401.html.twig
+++ b/templates/layout/page--401.html.twig
@@ -1,0 +1,18 @@
+{% embed 'page.html.twig' %}
+  {% block page_before_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'page-title'} %}
+      {% block container_content %}
+        <div class="page-title">
+          <h1>401 - {{ 'You are unauthorized to view this page.'|t }}</h1>
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_before_content %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/component.twig' with {container_element: 'error-content'} %}
+      {% block component_content %}
+        <p>{{ 'Sorry, but you are unauthorized to access this page. Please contact the site administrators.' }}</p>
+      {% endblock component_content %}
+    {% endembed %}
+  {% endblock page_content %}
+{% endembed %}

--- a/templates/layout/page--403.html.twig
+++ b/templates/layout/page--403.html.twig
@@ -1,0 +1,20 @@
+{% embed 'page.html.twig' %}
+  {% block page_before_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'page-title'} %}
+      {% block container_content %}
+        <div class="page-title">
+          <h1>403 - {{ 'You are not authorized to access this page.'|t }}</h1>
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_before_content %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/component.twig' with {container_element: 'error-content'} %}
+      {% block component_content %}
+        <p>{{ 'The page you are trying to access has restricted access. You need to log in and have sufficient permissions to view the content.'|t }}</p>
+        <h2>{{ 'Log in'|t }}</h2>
+        {{ drupal_block('user_login_block') }}
+      {% endblock component_content %}
+    {% endembed %}
+  {% endblock page_content %}
+{% endembed %}

--- a/templates/layout/page--404.html.twig
+++ b/templates/layout/page--404.html.twig
@@ -1,0 +1,18 @@
+{% embed 'page.html.twig' %}
+  {% block page_before_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'page-title'} %}
+      {% block container_content %}
+        <div class="page-title">
+          <h1>404 - {{ 'Sorry, the page you were looking for was not found.'|t }}</h1>
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_before_content %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/component.twig' with {container_element: 'error-content'} %}
+      {% block component_content %}
+        <p>{{ 'Check that you have typed in the page address correctly. We may have deleted or moved the content.'|t }}</p>
+      {% endblock component_content %}
+    {% endembed %}
+  {% endblock page_content %}
+{% endembed %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -63,17 +63,21 @@
   <main role="main" class="layout-main-wrapper">
     <a id="main-content" tabindex="-1"></a>
 
-    {# Move title inside the content area if page has navigation set to true. #}
-    {% if page.before_content and not move_before_content %}
-      {{ page.before_content }}
-    {% endif %}
+    {% block page_before_content %}
+      {# Move title inside the content area if page has navigation set to true. #}
+      {% if page.before_content and not move_before_content %}
+        {{ page.before_content }}
+      {% endif %}
+    {% endblock page_before_content %}
 
     <div class="main-content">
       <div class="layout-content {% if has_navigation %}has-navigation{% endif %} {% if move_before_content %}before-content--in-main{% endif %}">
         {% if page.before_content and move_before_content %}
           {{ page.before_content }}
         {% endif %}
-        {{ page.content }}
+        {% block page_content %}
+          {{ page.content }}
+        {% endblock page_content %}
       </div>{# /.layout-content #}
 
       {% if sidebar_first_output %}

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -46,7 +46,7 @@ msgid "See details"
 msgstr "Katso tarkemmat tiedot"
 
 msgid "Sorry, the page you were looking for was not found."
-msgstr "Etsimääsi sivua ei valitettavasti löytynyt"
+msgstr "Etsimääsi sivua ei valitettavasti löytynyt."
 
 msgid "Check that you have typed in the page address correctly. We may have deleted or moved the content."
 msgstr "Tarkista, että sivun osoite on kirjoitettu oikein. Olemme myös saattaneet poistaa tai siirtää sivun."

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -44,3 +44,12 @@ msgstr "Johdanto"
 msgctxt "Content liftup card hit for seeing more information on content page"
 msgid "See details"
 msgstr "Katso tarkemmat tiedot"
+
+msgid "Sorry, the page you were looking for was not found."
+msgstr "Etsimääsi sivua ei valitettavasti löytynyt"
+
+msgid "Check that you have typed in the page address correctly. We may have deleted or moved the content."
+msgstr "Tarkista, että sivun osoite on kirjoitettu oikein. Olemme myös saattaneet poistaa tai siirtää sivun."
+
+msgid "The page you are trying to access has restricted access. You need to log in and have sufficient permissions to view the content."
+msgstr "Sivu on nähtävillä vain kirjautuneille käyttäjille. Voit nähdä sivun sisällön jos kirjaudut sisään ja sinulla on riittävän laajat käyttöoikeudet."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -46,7 +46,7 @@ msgid "See details"
 msgstr "Se detaljer"
 
 msgid "Sorry, the page you were looking for was not found."
-msgstr "Tyvärr hittas inte sidan du sökte"
+msgstr "Tyvärr hittas inte sidan du sökte."
 
 msgid "Check that you have typed in the page address correctly. We may have deleted or moved the content."
 msgstr "Kontrollera att sidans adress är rätt skriven. Vi kan också ha tagit bort eller flyttat sidan."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -44,3 +44,9 @@ msgstr "Inledande paragraf"
 msgctxt "Content liftup card hit for seeing more information on content page"
 msgid "See details"
 msgstr "Se detaljer"
+
+msgid "Sorry, the page you were looking for was not found."
+msgstr "Tyvärr hittas inte sidan du sökte"
+
+msgid "Check that you have typed in the page address correctly. We may have deleted or moved the content."
+msgstr "Kontrollera att sidans adress är rätt skriven. Vi kan också ha tagit bort eller flyttat sidan."


### PR DESCRIPTION
To test:

1. Use any instance you want. Make it up to date with dev and then `composer require drupal/hdbt:dev-UHF-3864_login_block_for_403_page`
2. `make drush-cr`
3. `make shell`
4. `drush locale:check && drush locale:update && drush cr`
3. When not logged in try to access /user/1 and you should get a 403 page with login block. The layout still looks quite raw but its out of scope since there is story https://helsinkisolutionoffice.atlassian.net/browse/UHF-2879 where the layout work is done. Even tho it is a bit out of scope I added some level of styling and dom elements such as title and short description. Make sure they are all translated to English and Finnish. All Swedish translations are not here yet and since they are out of scope they also will be done in the story linked above.