### PR TITLE
UHF-4064: UHF-4064 Fix hdbt_get_settings function

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -157,6 +157,7 @@ function hdbt_preprocess_media(&$variables) {
 function hdbt_get_settings(string $setting, string $group = 'site_settings') {
   return Drupal::config('hdbt_admin_tools.site_settings')?->getOriginal("$group.$setting", FALSE);
 }
+
 /**
  * Implements hook_preprocess_HOOK().
  */

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -154,15 +154,9 @@ function hdbt_preprocess_media(&$variables) {
  * @return string|null
  *   Returns the desired setting as a string or false.
  */
-function hdbt_get_settings(string $setting, $group = 'site_settings') {
-  static $data;
-
-  if (!$data) {
-    $data = Drupal::config('hdbt_admin_tools.site_settings');
-  }
-  return $data->get("$group.$setting");
+function hdbt_get_settings(string $setting, string $group = 'site_settings') {
+  return Drupal::config('hdbt_admin_tools.site_settings')?->getOriginal("$group.$setting", FALSE);
 }
-
 /**
  * Implements hook_preprocess_HOOK().
  */


### PR DESCRIPTION
# Fix saving site settings (koro, color-palette and icon) [UHF-4064](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4064)
Saving of the site settings didn't work correctly before. Fixed that so that koro, color-palette and icon are correctly saved and applied.

## What was done
* Refactored the hdbt_get_settings function on hdbt.theme file.

## How to install
* Get any instance running latest dev.
* `composer require drupal/hdbt_admin:dev-UHF-4064_site_settings && composer require drupal/hdbt:dev-UHF-4064_site_settings`
* `make drush-cr`

## How to test
* First go to the `/admin/tools/site-settings` and select some different color-palette, koro and icon and save the page.
* Repeat the saving on all other language versions as well /fi /en /sv (not different selections - just the same you did on the first time)
* Go to the page and make sure the selections that you made are visible on the page.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/114
