### PR TITLE
Uhf 4256 mobile padding

### DIFF
--- a/src/scss/01_variables/_component_variables.scss
+++ b/src/scss/01_variables/_component_variables.scss
@@ -1,3 +1,4 @@
+$component-side-padding-breakpoint: $breakpoint-m;
 $component-spacing-breakpoint: $breakpoint-l;
 $component-spacing-mobile: $spacing-double; //        32px
 $component-spacing-desktop: $spacing-quadruple; //    64px
@@ -5,5 +6,5 @@ $component-title-spacing-mobile: $spacing; //         16px
 $component-title-spacing-desktop: $spacing; //        16px
 $component-desc-spacing-mobile: $spacing-and-half; // 24px
 $component-desc-spacing-desktop: $spacing-triple; //  48px
-$component-side-padding-mobile: $spacing-double; //   32px
+$component-side-padding-mobile: $spacing; //   16px
 $component-side-padding-desktop: $spacing-double; //  32px

--- a/src/scss/02_mixins/_component_mixins.scss
+++ b/src/scss/02_mixins/_component_mixins.scss
@@ -25,7 +25,7 @@
   padding-right: $component-side-padding-mobile;
 
   @if $component-side-padding-mobile != $component-side-padding-desktop {
-    @include breakpoint($component-spacing-breakpoint) {
+    @include breakpoint($component-side-padding-breakpoint) {
       padding-left: $component-side-padding-desktop;
       padding-right: $component-side-padding-desktop;
     }
@@ -37,7 +37,7 @@
   margin-right: - $component-side-padding-mobile;
 
   @if $component-side-padding-mobile != $component-side-padding-desktop {
-    @include breakpoint($component-spacing-breakpoint) {
+    @include breakpoint($component-side-padding-breakpoint) {
       margin-left: - $component-side-padding-desktop;
       margin-right: - $component-side-padding-desktop;
     }
@@ -48,7 +48,7 @@
 @mixin components-container-max-width() {
   max-width: $component-side-padding-mobile + $content-area-wrapper-width-max + $component-side-padding-mobile;
   @if $component-side-padding-mobile != $component-side-padding-desktop {
-    @include breakpoint($component-spacing-breakpoint) {
+    @include breakpoint($component-side-padding-breakpoint) {
       max-width: $component-side-padding-desktop + $content-area-wrapper-width-max + $component-side-padding-desktop;
     }
   }

--- a/src/scss/06_components/messages/_announcement.scss
+++ b/src/scss/06_components/messages/_announcement.scss
@@ -13,8 +13,8 @@
   box-shadow: 2px 2px 10px 0 rgba(0, 0, 0, 0.1);
   display: flex;
   justify-content: space-between;
-  margin-left: $spacing-half;
-  margin-right: $spacing-half;
+  margin-left: $component-side-padding-mobile;
+  margin-right: $component-side-padding-mobile;
   min-height: var(--announcement-bg-size);
   padding-bottom: $spacing;
   padding-left: calc(var(--announcement-bg-size) + #{$spacing});
@@ -32,8 +32,12 @@
 
   @include breakpoint($breakpoint-m) {
     --announcement-bg-size: #{$spacing-triple};
-    margin-left: $spacing-double;
-    margin-right: $spacing-double;
+  }
+  @if $component-side-padding-mobile != $component-side-padding-desktop {
+    @include breakpoint($component-side-padding-breakpoint) {
+      margin-left: $component-side-padding-desktop;
+      margin-right: $component-side-padding-desktop;
+    }
   }
 }
 

--- a/src/scss/06_components/pages/_basic-page.scss
+++ b/src/scss/06_components/pages/_basic-page.scss
@@ -1,5 +1,6 @@
 [data-unpublished]::before{
-  @include font('body');
+  @include font('small');
+  --line-height: 1;
   background: $color-error;
   color: $color-white;
   content: attr(data-unpublished);
@@ -10,8 +11,10 @@
   transform: rotate(-90deg) translateX(calc(-50% - 50vh));
   transform-origin: top left;
 
-  @include breakpoint($breakpoint-m) {
+  @include breakpoint($component-side-padding-breakpoint) {
     content: attr(data-unpublished-long);
+    @include font('body');
+    --line-height: 1.5;
   }
 }
 


### PR DESCRIPTION
# Mobile padding [UHF-4256](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4256)
A longer description of the task

## What was done
* Mobile padding was changed from 32px to 16px
* Announcements were converted to follow this padding too

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-4256_mobile_padding`
* Run `make drush-cr`

## How to test
* Describe how to test the feature
* Tip, you can paste this code to end of styles.scss to highlight the padding area for easier visual checking:
```

