### PR TITLE
UHF-3454: Set high school search filters to have autocomplete off

### DIFF
--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -127,6 +127,16 @@ function hdbt_content_language_switch_links_alter(array &$links) {
  * Implements hook_form_FORM_ID_alter().
  */
 function hdbt_content_form_views_exposed_form_alter(&$form, $form_state) {
+  // Setting high school search form autocompletes to off so that when
+  // users returning to the form won't see their previous selections
+  // and think that the results match to those because they don't.
+  if (str_starts_with($form['#id'], 'views-exposed-form-high-school-search-block')) {
+    $form['#attributes']['autocomplete'] = 'off';
+    $form['emphasis']['#attributes']['autocomplete'] = 'off';
+    $form['mission']['#attributes']['autocomplete'] = 'off';
+    $form['type']['#attributes']['autocomplete'] = 'off';
+  }
+
   // Handle only Unit search view form at this point.
   if (!str_starts_with($form['#id'], 'views-exposed-form-unit-search-block')) {
     return;


### PR DESCRIPTION
# Set high school search filters to have autocomplete off [UHF-3454](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3454)
Set the autocomplete off on the high school search so that when returning to the form the inputs don't have old values and not in sync with the results listing.

## What was done
* Using a form alter set the autocomplete off on the high school search paragraph form and its inputs.

## How to install
* Make sure your KASKO instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-3454_autocomplete_off`
* Run `make drush-cr`

## How to test
* Go to a page that has high school search or create one. 
* Select a filter and press search. 
* Switch to the map-version of the result listing.
* Click the "Open large version of the map" link.
* After you have been taken to the large version of the map press "back" on the browser.
* The form should now be in its original form and not have any filters set that you set before.

## Other PRs
* 
