### PR TITLE
UHF-4423: Reverted attributes for the body class.

### DIFF
--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -56,7 +56,7 @@
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
   </head>
-  <body>
+  <body{{ attributes }}>
     {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.


### PR DESCRIPTION
# Hotfix for html.html.twig

Revert attributes for the body tag.
