### PR TITLE
UHF-3165: Reordered errand service fields inside accordion

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1144,12 +1144,12 @@ function hdbt_preprocess_tpr_errand_service(&$variables) {
   $details = [];
 
   $detail_fields = [
+    'process_description' => t('How the process works', [], ['context' => 'Errand service detail heading']),
     'processing_time' => t('Processing time', [], ['context' => 'Errand service detail heading']),
     'costs' => t('Fees', [], ['context' => 'Errand service detail heading']),
     'expiration_time' => t('Validity period', [], ['context' => 'Errand service detail heading']),
     'information' => t('Additional information', [], ['context' => 'Errand service detail heading']),
     'links' => t('Additional links', [], ['context' => 'Errand service detail heading']),
-    'process_description' => t('How the process works', [], ['context' => 'Errand service detail heading']),
   ];
 
   foreach ($detail_fields as $detail_key => $heading) {


### PR DESCRIPTION
# [UHF-3165](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3165)

## How to install
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-3165`
* Run `make drush-cr`

## How to test
- Open any service page that contains an errand service with process_description field. For example: `/tpr-service/3622`.
- Make sure process description is shown first
