### PR TITLE
Disable social media block for news

### DIFF
--- a/templates/module/helfi-news-item/node--news-item.html.twig
+++ b/templates/module/helfi-news-item/node--news-item.html.twig
@@ -59,9 +59,6 @@
       </div>
     {% endif %}
 
-    {# Social media share links #}
-    {{ drupal_block('hdbt_content_social_sharing_block') }}
-
     {# Tags #}
     {% if content.field_news_item_tags|render %}
       <section class="content-tags"  aria-label="{{ 'Tags'|t({}, {'context': 'Label for screen reader software users explaining that this is a list of tags related to this page.'}) }}">


### PR DESCRIPTION
## What was done
* Disabled social media block for news

## How to install
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-X-disable-social-media-block`
* Run `make drush-cr`

## How to test
* Create a News item node  and make sure it doesn't throw 5xx error anymore.

