### PR TITLE
UHF-3504: Added check if social media icon link renders

### DIFF
--- a/templates/paragraphs/paragraph--social-media-link.html.twig
+++ b/templates/paragraphs/paragraph--social-media-link.html.twig
@@ -51,6 +51,8 @@
       {{ content.field_icon }}
       <span class="visually-hidden">{{ icon_name }}</span>
     {% endset %}
-   {{ link(link_title, content.field_social_media_link[0]['#url'], link_attributes) }}
+    {% if content.field_social_media_link[0]['#url']|render %}
+      {{ link(link_title, content.field_social_media_link[0]['#url'], link_attributes) }}
+    {% endif %}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
# TASKNAME [UHF-3504](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3504)

Added a check that the social media icon url exists before rendering

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Make sure you have the latest from platform config as well (configs were added in tag number 2.6.8) 
* If not run in shell `composer upgrade drupal/helfi_platform_config` and `drush updb; drush cr`

Before updating the HDBT theme, try adding the contact card listing paragraph/yhteystietokorttilistau (i.ex. to a standard page) without filling any social media links to a contact card, this should result in an error on the page when viewed.

* Update the HDBT theme
    * Run `make shell` in project root
    * `composer require drupal/hdbt:dev-UHF-3504-contact-card-fix`
    * `drush cr`

## How to test
* The previously mentioned error should now disappear and the social media link renders only if the actual link is filled in

