### PR TITLE
UHF-3504: Removed unnecessary link attributes

### DIFF
--- a/templates/paragraphs/paragraph--social-media-link.html.twig
+++ b/templates/paragraphs/paragraph--social-media-link.html.twig
@@ -52,7 +52,7 @@
       <span class="visually-hidden">{{ icon_name }}</span>
     {% endset %}
     {% if content.field_social_media_link[0]['#url']|render %}
-      {{ link(link_title, content.field_social_media_link[0]['#url'], link_attributes) }}
+      {{ link(link_title, content.field_social_media_link[0]['#url']) }}
     {% endif %}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
# Henkilön yhteystietokortti [UHF-3504](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3504)

Removed unnecessary link_attributes from social media links paragraph

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-3504-contact-card-listing-fix`
    * `drush cr`

