### PR TITLE
Fix video title heading level and rendering problem

### DIFF
--- a/templates/paragraphs/paragraph--remote-video.html.twig
+++ b/templates/paragraphs/paragraph--remote-video.html.twig
@@ -13,6 +13,12 @@
 {% if not paragraph_title|render and not paragraph_desc|render %}
   {% set header_class = 'component--no-header' %}
 {% endif %}
+
+{% set video_title_level = 'h2' %}
+{% if paragraph_title|render %}
+  {% set video_title_level = 'h3' %}
+{% endif %}
+
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
     {
@@ -29,7 +35,9 @@
       <div class="remote-video__video">
         {{ video }}
       </div>
-      <h3 class="remote-video__video-title">{{ video_title }}</h3>
+      {% if video_title|render %}
+        <{{ video_title_level }} class="remote-video__video-title">{{ video_title }}</{{ video_title_level }}>
+      {% endif %}
       <div class="remote-video__video-desc">{{ video_desc }}</div>
     {% endblock component_content %}
   {% endembed %}


### PR DESCRIPTION
# Video title problems
With current templates we get empty headings and wrong level headings in video components

## What was done
* video title level is now changed based on if the component has a title
  * video title is h2 for no component title
  * video title is h3 for videos that have component title
* Video title heading element is removed if its contents would be empty

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-X_video_title_heading_fix`
* Run `make drush-cr`

## How to test
* Test first without the fix
* Create a page with three video elements
  * One with no video title (below video)
    * Will have an empty h3 element
  * One with video title (below video) and no component title (above video)
    * Will have possibly incorrect h3 level
  * One with video title and component title
    * This behaviour is and will be correct h2 for component title and h3 for video title
* Get branch, drush cr
* Check titles
  * first should not have empty h3 element
  * second should have h2 video title element
  * third should remain unchanged h2 for component title and h3 for video title
