### PR TITLE
Uhf 4665 iframe title for map

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -157,6 +157,7 @@ function hdbt_preprocess_media(&$variables) {
       $video_url = $variables['media']->field_media_oembed_video->value;
       $provider = $url_resolver->getProviderByUrl($video_url);
       $variables['video_service_url'] = rtrim($provider->getUrl(), '/');
+      $variables['iframe_title'] = $variables['media']->field_media_oembed_video->iframe_title;
     }
   }
 }
@@ -844,6 +845,50 @@ function hdbt_preprocess_paragraph(array &$variables) {
     // Icon name for accessibility.
     if (!$paragraph->get('field_icon')->isEmpty()) {
       $variables['icon_name'] = ucfirst($paragraph->get('field_icon')->icon);
+    }
+  }
+
+  // Map paragraph
+  if (
+    $paragraph_type == 'map' &&
+    $paragraph->hasField('field_map_map') &&
+    $paragraph->hasField('field_iframe_title')
+    ) {
+    $iframe_title = $paragraph->get('field_iframe_title')->value;
+    if ($iframe_title) {
+      dump($paragraph->get('field_map_map')->entity);
+      $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = $iframe_title;
+      
+    } else {
+      $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = t('Location on map');
+    }
+  }
+
+  // Remote video paragraph
+  if (
+    $paragraph_type == 'remote_video' &&
+    $paragraph->hasField('field_remote_video') &&
+    $paragraph->hasField('field_iframe_title')
+    ) {
+    $iframe_title = $paragraph->get('field_iframe_title')->value;
+    if ($iframe_title) {
+      $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = $iframe_title;
+    } else {
+      $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = t('Embedded video');
+    }
+  }
+
+  // Chart paragraph
+  if (
+    $paragraph_type == 'chart' &&
+    $paragraph->hasField('field_chart_chart') &&
+    $paragraph->hasField('field_iframe_title')
+    ) {
+    $iframe_title = $paragraph->get('field_iframe_title')->value;
+    if ($iframe_title) {
+      $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = $iframe_title;
+    } else {
+      $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = t('Data chart');
     }
   }
 }

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -853,10 +853,9 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph_type == 'map' &&
     $paragraph->hasField('field_map_map') &&
     $paragraph->hasField('field_iframe_title')
-    ) {
+  ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
     if ($iframe_title) {
-      dump($paragraph->get('field_map_map')->entity);
       $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = $iframe_title;
 
     }
@@ -870,7 +869,7 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph_type == 'remote_video' &&
     $paragraph->hasField('field_remote_video') &&
     $paragraph->hasField('field_iframe_title')
-    ) {
+  ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
     if ($iframe_title) {
       $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = $iframe_title;
@@ -885,7 +884,7 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph_type == 'chart' &&
     $paragraph->hasField('field_chart_chart') &&
     $paragraph->hasField('field_iframe_title')
-    ) {
+  ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
     if ($iframe_title) {
       $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = $iframe_title;

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -848,7 +848,7 @@ function hdbt_preprocess_paragraph(array &$variables) {
     }
   }
 
-  // Map paragraph
+  // Map paragraph.
   if (
     $paragraph_type == 'map' &&
     $paragraph->hasField('field_map_map') &&
@@ -858,13 +858,14 @@ function hdbt_preprocess_paragraph(array &$variables) {
     if ($iframe_title) {
       dump($paragraph->get('field_map_map')->entity);
       $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = $iframe_title;
-      
-    } else {
+
+    }
+    else {
       $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = t('Location on map');
     }
   }
 
-  // Remote video paragraph
+  // Remote video paragraph.
   if (
     $paragraph_type == 'remote_video' &&
     $paragraph->hasField('field_remote_video') &&
@@ -873,12 +874,13 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
     if ($iframe_title) {
       $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = $iframe_title;
-    } else {
+    }
+    else {
       $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = t('Embedded video');
     }
   }
 
-  // Chart paragraph
+  // Chart paragraph.
   if (
     $paragraph_type == 'chart' &&
     $paragraph->hasField('field_chart_chart') &&
@@ -887,7 +889,8 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
     if ($iframe_title) {
       $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = $iframe_title;
-    } else {
+    }
+    else {
       $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = t('Data chart');
     }
   }

--- a/templates/media/media--remote-video.html.twig
+++ b/templates/media/media--remote-video.html.twig
@@ -79,7 +79,7 @@
           'src': media_attributes.src,
           'height': media_attributes.height,
           'width': media_attributes.width,
-          'title': media_attributes.title
+          'title': iframe_title,
         }
       }
     }


### PR DESCRIPTION
# iFrame title [UHF-4665](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4665)

Added iFrame title fields for remote video, chart and map paragraphs

## What was done
* Added new mandatory fields for the three paragraphs, the fields have a default value from preprocessing before the field is filled by the content creator.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `make shell` in project root
    * `composer require drupal/helfi_platform_config:dev-UHF-4665-iframe-title-for-map`
    * `composer require drupal/hdbt:dev-UHF-4665-iframe-title-for-map`
    * `drush updb; drush cr;`

## How to test
* Create a standard page and add a map, remote video and chart paragraphs to the page. They should now have a new field called "assistive technology title". Fill in the title and it will appear on the embedded contents iframe title-attribute.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/312
