### PR TITLE
UHF-5126: Social media wsod

### DIFF
--- a/templates/content/social-media-links.html.twig
+++ b/templates/content/social-media-links.html.twig
@@ -1,13 +1,14 @@
 <div class="social-media__items">
   {% set classes = ['social-media__item'] %}
   {% for element in elements %}
-    {% set link_title %}
-      {% include "@hdbt/misc/icon.twig" with {icon: element.img, label: element.text } %}
-    {% endset %}
-    {% set link_attributes = {
-      'class': classes|merge(element.classes),
-    } %}
-    {{ link(link_title, element.url, link_attributes) }}
+    {% if element.url and element.img and element.text %}
+      {% set link_title %}
+        {% include "@hdbt/misc/icon.twig" with {icon: element.img, label: element.text } %}
+      {% endset %}
+      {% set link_attributes = {
+        'class': classes|merge(element.classes),
+      } %}
+      {{ link(link_title, element.url, link_attributes) }}
+    {% endif %}
   {% endfor %}
 </div>
-

--- a/templates/module/helfi-news-item/node--news-item.html.twig
+++ b/templates/module/helfi-news-item/node--news-item.html.twig
@@ -59,6 +59,9 @@
       </div>
     {% endif %}
 
+    {# Social media share links #}
+    {{ drupal_block('hdbt_content_social_sharing_block') }}
+
     {# Tags #}
     {% if content.field_news_item_tags|render %}
       <section class="content-tags"  aria-label="{{ 'Tags'|t({}, {'context': 'Label for screen reader software users explaining that this is a list of tags related to this page.'}) }}">


### PR DESCRIPTION
# Social media block [UHF-5126](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5126)

The social media sharing block caused WSOD when enabled.

## What was done
* Enable the social media block and check that necessary variables are available when trying to print the links

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-5126_social_media_wsod && composer require drupal/helfi_platform_config:dev-UHF-5126_social_media_wsod`
* Run `make drush-updb drush-cr`

## How to test
* Create a news item and check that the social media links get rendered without errors

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/316
