### PR TITLE
UHF-4665: Added check if chart, map or video field has content

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -817,12 +817,13 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph->hasField('field_iframe_title')
   ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
-    if ($iframe_title) {
-      $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = $iframe_title;
-
-    }
-    else {
-      $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = t('Location on map');
+    if (!$paragraph->get('field_map_map')->isEmpty()) {
+      if ($iframe_title) {
+        $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = $iframe_title;
+      }
+      else {
+        $paragraph->get('field_map_map')->entity->get('field_media_hel_map')->title = t('Location on map');
+      }
     }
   }
 
@@ -833,11 +834,13 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph->hasField('field_iframe_title')
   ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
-    if ($iframe_title) {
-      $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = $iframe_title;
-    }
-    else {
-      $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = t('Embedded video');
+    if (!$paragraph->get('field_remote_video')->isEmpty()) {
+      if ($iframe_title) {
+        $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = $iframe_title;
+      }
+      else {
+        $paragraph->get('field_remote_video')->entity->get('field_media_oembed_video')->iframe_title = t('Embedded video');
+      }
     }
   }
 
@@ -848,11 +851,13 @@ function hdbt_preprocess_paragraph(array &$variables) {
     $paragraph->hasField('field_iframe_title')
   ) {
     $iframe_title = $paragraph->get('field_iframe_title')->value;
-    if ($iframe_title) {
-      $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = $iframe_title;
-    }
-    else {
-      $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = t('Data chart');
+    if (!$paragraph->get('field_chart_chart')->isEmpty()) {
+      if ($iframe_title) {
+        $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = $iframe_title;
+      }
+      else {
+        $paragraph->get('field_chart_chart')->entity->get('field_helfi_chart_title')->value = t('Data chart');
+      }
     }
   }
 }


### PR DESCRIPTION
# [UHF-4665](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4665)

Map and chart paragraphs didn't have the media field as a mandatory field which led to an error

## What was done
* Added a check to preprocessing that the media fields have content


## How to test before installing changes
* Add a chart paragraph to a standard page without the chart media file. This should result to an error on the page.
* Remove the chart and test the same with the map paragraph, should also lead to an error

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-4665-fix-for-chart`
* Run `make drush-cr`

## How to test after installing changes
* Refresh the page that has the chart paragraph without the media file. The error should now be gone.
* Test the same with the map paragraph
