### PR TITLE
UHF-5228: disable genesys button

### DIFF
--- a/dist/js/disable-genesys-button.min.js
+++ b/dist/js/disable-genesys-button.min.js
@@ -1,0 +1,1 @@
+!function(e,t,n){"use strict";t.behaviors.disable_genesys_button={attach:function(n,i){"undefined"==typeof _genesys&&e("#openChat").replaceWith("<div>"+t.t("Chat is not in use.")+"</div>")}}}(jQuery,Drupal,drupalSettings);

--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -114,3 +114,12 @@ environment-indicator:
   css:
     theme:
       dist/css/environment-indicator.min.css: {}
+
+disable_genesys_button:
+  version: 1.x
+  js:
+    dist/js/disable-genesys-button.min.js: {}
+  dependencies:
+  - core/jquery
+  - core/drupal
+  - core/drupalSettings

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -89,6 +89,9 @@ function hdbt_preprocess_html(&$variables) {
 
   // Add Matomo analytics.
   $variables['#attached']['library'][] = 'hdbt/matomo';
+
+  // Disable Genesys button if the chat element does not exist.
+  $variables['#attached']['library'][] = 'hdbt/disable_genesys_button';
 }
 
 /**

--- a/src/js/disable-genesys-button.js
+++ b/src/js/disable-genesys-button.js
@@ -1,0 +1,13 @@
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.disable_genesys_button = {
+    attach: function (context, settings) {
+      // Don't show the button if the chat element does not exist.
+      if (typeof(_genesys) === 'undefined') {
+        $('#openChat').replaceWith('<div>' + Drupal.t('Chat is not in use.') + '</div>');
+      }
+    }
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -203,3 +203,6 @@ msgstr "Mene seuraavalle sivulle"
 msgctxt "Pagination next page link text"
 msgid "Next"
 msgstr "Seuraava"
+
+msgid "Chat is not in use."
+msgstr "Chat ei ole käytössä."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -200,3 +200,6 @@ msgstr "Gå till nästa sida"
 msgctxt "Pagination next page link text"
 msgid "Next"
 msgstr "Nästa"
+
+msgid "Chat is not in use."
+msgstr "Chatten används inte."


### PR DESCRIPTION
# Genesys chatin avaavan napin disablointi [UHF-5228](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5228)
Disabling (or more precisely, not displaying) the button that opens the chat when the Genesys chat element does not exist on the page.

## What was done
* Added a JavaScript library that checks the existence of the Genesys chat element and replaces the button with a more informative text if it does not exist

## How to install
* Set up STRATEGIA instance with `make fresh`
* Get this branch of the HDBT theme: `composer require drupal/hdbt:dev-UHF-5228_disable_genesys_button`
* Get the equivalent branch of the Platform Config module: `composer require drupal/helfi_platform_config:dev-UHF-5228_disable_genesys_button`
* Enter the container: `make shell`
* Update the translations: `drush locale:check && drush locale:update && drush cr`

## How to test
* Navigate to https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/tuki-ja-neuvonta/helsinki-info
  * Optionally, edit the page and see how the "Aloita chat" element is just a link. The Platform Config PR replaces it with a button.
* See how the chat does not exist on that page and "Chat is not in use." is displayed where the button should be
* Edit the block config at https://strategia.docker.so/en/decision-making/admin/structure/block/manage/genesyschatneuvonta and add `/tuki-ja-neuvonta/helsinki-info` in the "Pages" input
* Open the "Helsinki-info" page again and see the chat element in the lower right corner and also how the button is now in place
  * Optionally, see that the "Aloita chat" element is a button and not a link
* Create language versions of the page and check that the translations work

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/324