### PR TITLE
UHF-X Fix missing TPR Unit email

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1161,11 +1161,6 @@ function hdbt_preprocess_tpr_unit(&$variables) {
   }
   $entity = $variables['entity'];
 
-  // Convert email link to Url object and set as new variable for the template.
-  if (!$entity->email->isEmpty()) {
-    $variables['unit_email_link'] = Url::fromUri('mailto:' . $entity->email->value);
-  }
-
   // Add current Unit Url to variable.
   $variables['unit_url'] = !$entity->isNew() ? $entity->toUrl('canonical') : NULL;
 }

--- a/modules/hdbt_content/hdbt_content.module
+++ b/modules/hdbt_content/hdbt_content.module
@@ -13,6 +13,7 @@ use Drupal\block\Entity\Block;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\helfi_tpr\Entity\Service;
 use Drupal\helfi_tpr\Entity\Unit;
 use Drupal\node\NodeInterface;
@@ -108,11 +109,16 @@ function template_preprocess_tpr_unit_contact_information(array &$variables) : v
     $variables['content'][$key] = $variables['elements'][$key];
   }
   if (isset($variables['elements']['#tpr_unit'])) {
-    $variables['entity'] = $variables['elements']['#tpr_unit'];
+    $entity = $variables['entity'] = $variables['elements']['#tpr_unit'];
 
     // Get 'show_www' field value and pass it to the template.
     $show_www = $variables['entity']->get('show_www')->value;
     $variables['show_www'] = boolval($show_www);
+
+    // Convert email link to Url object and set as new variable for the template.
+    if (!$entity->email->isEmpty()) {
+      $variables['unit_email_link'] = Url::fromUri('mailto:' . $entity->email->value);
+    }
   }
 }
 


### PR DESCRIPTION
# UHF-X Fix missing TPR Unit email 

## What was done
* Moved TPR Unit email field preprocessing to tpr_unit_contact_information preprocess.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-X_fix_missing_tpr_unit_email`
* Run `make drush-cr`

## How to test
* Run `make drush-cr`
* Go to f.e. https://helfi-asuminen.docker.so/fi/asuminen/vuokra-asunnon-haku-neuvonta and check that the Email field has reappeared

## Designers review

One of the checkboxes below needs to be checked (`[x]`)

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
