### PR TITLE
UHF-X Add new empty base module for global navigation theming.

### DIFF
--- a/modules/hdbt_global_navigation/hdbt_global_navigation.info.yml
+++ b/modules/hdbt_global_navigation/hdbt_global_navigation.info.yml
@@ -1,0 +1,8 @@
+name: 'HDBT Global Navigation'
+type: module
+description: 'Provides theming to global navigation feature'
+core: 8.x
+core_version_requirement: ^8 || ^9
+package: 'Theme'
+'interface translation project': hdbt_global_navigation
+'interface translation server pattern': themes/contrib/hdbt/modules/hdbt_global_navigation/translations/%language.po


### PR DESCRIPTION
# Add base module for global navigation

## What was done
Added new empty module inside hdbt/modules to provide a place for adding global navigation theming

## How to install
(Inside hdbt directory)
- `git fetch`
- `git co origin/UHF-X-global-navigation-base ` 


## How to test
- `drush cr`
- `drush en hdbt_global_navigation`

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
