### PR TITLE
UHF-X: Fix translation bug

### DIFF
--- a/translations/fi.po
+++ b/translations/fi.po
@@ -100,8 +100,8 @@ msgctxt "Short description for editors about current page being unpublished"
 msgid "Unpublished"
 msgstr "Julkaisematon"
 
-msgid "Sorry, the page you were looking for was not found."
-msgstr "Etsimääsi sivua ei valitettavasti löytynyt."
+msgid "Sorry, the page you were looking for was not found"
+msgstr "Etsimääsi sivua ei valitettavasti löytynyt"
 
 msgctxt "The helper text before the node changed timestamp"
 msgid "Updated"


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Finnish translation does not match the english key due to an extra period.

## What was done
<!-- Describe what was done -->

* Period was removed from both Finnish translation and the Finnish version of the key

## How to install

* Check a 404 page in Finnish first to see if it has text in English in your instance
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_404_translation_error`
* Run `make drush-cr`
* Run `make shell`
* Run in shell `drush locale:check && drush locale:update`
* Run `Flush all caches` in drupal admin teardrop-menu

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check first that you can see English text in Finnish 404 page
* [x] Install this branch and get its translations as explained above
* [x] Check that the English text has changed to Finnish as it should be
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
