### PR TITLE
UHF-X improve logo accessibility

### DIFF
--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -26,7 +26,6 @@
       'logo',
       'logo--header',
     ],
-    'title': site_name,
     'id': 'logo--header',
     'rel': 'home',
   } %}

--- a/templates/layout/region--footer-bottom.html.twig
+++ b/templates/layout/region--footer-bottom.html.twig
@@ -25,7 +25,6 @@
               'logo',
               'logo--footer',
             ],
-            'title': site_name,
             'rel': 'home',
           } %}
           {{ link(link_title, site_front_url, link_attributes) }}

--- a/templates/misc/logo.twig
+++ b/templates/misc/logo.twig
@@ -1,23 +1,23 @@
 {% set logo = 'helsinki' %}
 {% set logo_class = 'logo__icon logo__icon--fi' %}
-{% set logo_alt = 'Helsinki' %}
+{% set logo_alt = 'Helsinki-kehystunnus' %}
 
 {% if current_langcode == 'en' %}
   {% set logo = 'helsinki' %}
   {% set logo_class = 'logo__icon logo__icon--en' %}
-  {% set logo_alt = 'Helsinki' %}
+  {% set logo_alt = 'Helsinki logo' %}
 {% endif %}
 
 {% if current_langcode == 'sv' %}
   {% set logo = 'helsinki-sv' %}
   {% set logo_class = 'logo__icon logo__icon--sv' %}
-  {% set logo_alt = 'Helsingfors' %}
+  {% set logo_alt = 'Helsingfors logo' %}
 {% endif %}
 
 {% if current_langcode == 'ru' %}
   {% set logo = 'helsinki-ru' %}
   {% set logo_class = 'logo__icon logo__icon--ru' %}
-  {% set logo_alt = 'Xeльcинки' %}
+  {% set logo_alt = 'Логотип Хельсинки' %}
 {% endif %}
 
 {% include "@hdbt/misc/icon.twig" with {icon: logo, label: logo_alt, class: logo_class} %}


### PR DESCRIPTION
# UHF-X improve logo accessibility
<!-- What problem does this solve? -->
* The title attribute in logos is read poorly in screen readers and are only visible on devices with a pointer.
* The Helsinki logo is read out loud as "Helsinki", which is wrong, it's the logo of Helsinki or Helsinki city.

## What was done
<!-- Describe what was done -->

* Title attribute removed
* Helsinki logo was properly named according to [this chat](https://helsinkicity.slack.com/archives/G01EWJJVAUW/p1655821233137499?thread_ts=1655705554.640059&cid=G01EWJJVAUW).

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_improve_logo_a11y`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that title attribute is gone in both header and footer logos
* [x] Check that aria-label now describes the logo properly
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
