### PR TITLE
UHF-6198: Cache mobilemenu response to localstorage

### DIFF
--- a/src/js/nav-global.js
+++ b/src/js/nav-global.js
@@ -117,6 +117,7 @@ const Panel = {
   data:null,
   current: 0,
   cacheKey: 'hdbt-mobile-menu',
+  enableCache: true,
   selectors:{
     container:'#mmenu',
     rootId:'mmenu__panels',
@@ -251,7 +252,7 @@ const Panel = {
     const now = new Date().getTime();
 
     // Return cached menu if timestamp is less than hour old. 
-    if(cache && cache.timestamp > now - 60 * 60 * 1000) {
+    if(this.enableCache && cache && cache.timestamp > now - 60 * 60 * 1000) {
       this.data = cache.value;
       return;
     }

--- a/src/js/nav-global.js
+++ b/src/js/nav-global.js
@@ -116,6 +116,7 @@ const Panel = {
   size: 5,
   data:null,
   current: 0,
+  cacheKey: 'hdbt-mobile-menu',
   selectors:{
     container:'#mmenu',
     rootId:'mmenu__panels',
@@ -246,7 +247,21 @@ const Panel = {
     },10);
   },
   load: async function(){
+    const cache = JSON.parse(localStorage.getItem(this.cacheKey));
+    const now = new Date().getTime();
+
+    // Return cached menu if timestamp is less than hour old. 
+    if(cache && cache.timestamp > now - 60 * 60 * 1000) {
+      this.data = cache.value;
+      return;
+    }
+
     const MENU = await( await fetch('/global-mobile-menu.json')).json();
+    localStorage.setItem(this.cacheKey, JSON.stringify({
+      value: MENU,
+      timestamp: new Date().getTime()
+    }));
+
     this.data = MENU;
   },
   start: async function(){

--- a/src/js/nav-global.js
+++ b/src/js/nav-global.js
@@ -251,10 +251,12 @@ const Panel = {
     const cache = JSON.parse(localStorage.getItem(this.cacheKey));
     const now = new Date().getTime();
 
-    // Return cached menu if timestamp is less than hour old. 
-    if(this.enableCache && cache && cache.timestamp > now - 60 * 60 * 1000) {
+    // Return cached menu if timestamp is less than hour old.
+    if (this.enableCache && cache && cache.timestamp > now - 60 * 60 * 1000) {
       this.data = cache.value;
       return;
+    } else {
+      console.log('Mobile menu cache is disabled');
     }
 
     const MENU = await( await fetch('/global-mobile-menu.json')).json();


### PR DESCRIPTION
# [UHF-6198 Mobile menu caching](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6198)
Cache the mobile menu request to local storage, eliminating the need to make the same request in succession.

## What was done
Added logic to cache the mobile menu request into localstorage. Added timestamp to act as a cache invalidator. 

## How to install

Mobile menu is still a work in progress. To test this issue, some tricks are needed:
* Get the feature branch from platfom config: `composer require drupal/helfi_platform_config:dev-UHF-6038-menu-data-syncing`
* Enable global menu feature: `drush en helfi_navigation -y`
* (Get this branch: `composer require drupal/hdbt:dev-UHF-6198-mobile-menu-caching)` Change line 260 of `themes/contrib/hdbt/src/js/nav-global.js` to `const MENU = mockmenu;`
* Pull the branch `UHF-6038-menu-data-syncing` into your local HDBT. This commit adds some templates - pulling it will prevents the current version of platform config from crashing.
* Run `nvm use; npm i; npm run build`
* Clear cache `drush cr`

## How to test
* Load a page and scale down to mobile view. You should see the hamburger menu in the top right corner of the page. Click it.
* After the menu has loaded, check that it's been cached: `const x = JSON.parse(localStorage.getItem('hdbt-mobile-menu'))` in the console. The returned object should hold the menu data + a timestamp.
* Check the timestamp: `x.timestamp` to print it out.
* Overwrite the timestamp with and hour old one: `let y = x; y.timestamp = new Date().getTime() - 60 * 60 * 1000; localstrorage.setItem('hdbt-mobile-menu', JSON.stringify(y))`;. Take note of the timestamp you just created.
* Reload the page and open the mobile menu again. Print out the cache timestamp again (JSON.parse(localStorage.getItem('hdbt-mobile-menu')).timestamp). The hour old timestamp should have been updated with an up-to-date one.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

