### PR TITLE
UHF-6300: Remove ctools dependencies from hdbt install config

### DIFF
--- a/config/install/block.block.hdbt_page_title.yml
+++ b/config/install/block.block.hdbt_page_title.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  module:
-    - ctools
   theme:
     - hdbt
 id: hdbt_page_title

--- a/config/install/block.block.heroblock.yml
+++ b/config/install/block.block.heroblock.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt

--- a/config/install/block.block.main_navigation_level_2.yml
+++ b/config/install/block.block.main_navigation_level_2.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - system.menu.main
   module:
-    - ctools
     - menu_block_current_language
   theme:
     - hdbt

--- a/config/install/block.block.sidebarcontentblock.yml
+++ b/config/install/block.block.sidebarcontentblock.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt


### PR DESCRIPTION
# [UHF-6300](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6300)

## What was done
* Removed ctools dependencies from hdbt install config.

## How to test
* Check site specific PR's for testing instructions.

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* Related module PR:
  * https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/352
* Site specific PRs:
  * https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/435
  * https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/419
  * https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/308
  * https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/204
  * https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/95
  * https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/43
  * https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/114
  * https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/113