### PR TITLE
UHF-6727: Fix menu button help text for some screen readers

### DIFF
--- a/templates/block/block--external-menu-block-fallback.html.twig
+++ b/templates/block/block--external-menu-block-fallback.html.twig
@@ -40,13 +40,26 @@
 
 {# Do we want to render navigation with content from another instance "globally" #}
 {% if use_global_navigation %}
+
+  {% set menu_open %}
+    <span aria-hidden="true">{{ 'Menu'|t }}</span>
+    <span class="visually-hidden">{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}</span>
+  {% endset %}
+
+  {% set menu_close %}
+    <span aria-hidden="true">{{ 'Close'|t }}</span>
+    <span class="visually-hidden">{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}</span>
+  {% endset %}
+
+  {# Fallback menu button #}
   <div class="menu-toggle-anchor">
-    <a href="#" class="menu-toggle__close"><span aria-label="{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}">{{ 'Close'|t }}</a>
-    <a href="#menu" class="menu-toggle__open"><span aria-label="{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}">{{ 'Menu'|t }}</a>
+    <a href="#" class="menu-toggle__close">{{ menu_close }}</a>
+    <a href="#menu" class="menu-toggle__open">{{ menu_open }}</a>
   </div>
+  {# Slightly more accessible js enhanced menu button #}
   <button class="menu-toggle-button js-menu-toggle-button" aria-expanded="false" aria-controls="menu-dropdown">
-    <span class="menu-toggle__open"><span aria-label="{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}">{{ 'Menu'|t }}</span></span>
-    <span class="menu-toggle__close"><span aria-label="{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}">{{ 'Close'|t }}</span></span>
+    <span class="menu-toggle__open">{{ menu_open }}</span>
+    <span class="menu-toggle__close">{{ menu_close }}</span>
   </button>
   <nav id="menu-dropdown" role="navigation" class="menu-dropdown" aria-labelledby="menu-description">
     <div class="menu-dropdown__wrapper" aria-labelledby="menu-description">

--- a/templates/block/block--mobile-navigation.html.twig
+++ b/templates/block/block--mobile-navigation.html.twig
@@ -36,13 +36,24 @@
 {% if not use_global_navigation %}
   {% set attributes = attributes.addClass('block--mobile-navigation').addClass('mobile-navigation') %}
 
+
+  {% set menu_open %}
+    <span aria-hidden="true">{{ 'Menu'|t }}</span>
+    <span class="visually-hidden">{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}</span>
+  {% endset %}
+
+  {% set menu_close %}
+    <span aria-hidden="true">{{ 'Close'|t }}</span>
+    <span class="visually-hidden">{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}</span>
+  {% endset %}
+
   <label for="cssmenu-toggle-checkbox" class="cssmenu-toggle" role="button" id="cssmenu-toggle">
-    <span class="cssmenu-toggle__open"><span aria-label="{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}">{{ 'Menu'|t }}</span></span>
-    <span class="cssmenu-toggle__close"><span aria-label="{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}">{{ 'Close'|t }}</span></span>
+    <span class="cssmenu-toggle__close">{{ menu_close }}</span>
+    <span class="cssmenu-toggle__open">{{ menu_open }}</span></span>
   </label>
   <button class="cssmenu-toggle-button js-cssmenu-toggle-button" aria-expanded="false">
-    <span class="cssmenu-toggle__open"><span aria-label="{{ 'Open navigation menu'|t({}, {'context': 'Mobile navigation menu open button text for screen readers'}) }}">{{ 'Menu'|t }}</span></span>
-    <span class="cssmenu-toggle__close"><span aria-label="{{ 'Close navigation menu'|t({}, {'context': 'Mobile navigation menu close button text for screen readers'}) }}">{{ 'Close'|t }}</span></span>
+    <span class="cssmenu-toggle__open">{{ menu_open }}</span>
+    <span class="cssmenu-toggle__close">{{ menu_close }}</span>
   </button>
 
   <nav class="cssmenu-menu" aria-labelledby="cssmenu-menu-description">


### PR DESCRIPTION
# [UHF-6727](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6727)
<!-- What problem does this solve? -->

Fixes a problem found in 14.9 accessibility checks that some screen readers on some browsers do not read the help text from aria-label elements that do not have a role. This moves the text out from aria-label attribute into the actual content and hides it from non-screen readers while hiding the shown text from screen readers with aria-hidden.

This code was discussed and should be the one we aim for:
![image](https://user-images.githubusercontent.com/1191667/191501566-f617ee6b-4343-453f-83ff-de64eb624920.png)


## What was done
<!-- Describe what was done -->

* Global and local menu were fixed by moving the help text outside from aria-label to actual page content.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code is rendered as shown in above screenshot
* [ ] Check that code does not break the regular users experience of the menu-button
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
