### PR TITLE
UHF-X Lang attribute fix

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -422,8 +422,11 @@ function hdbt_preprocess_input__submit(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_preprocess_menu(&$variables) {
+  $apply_lang_attribute = array_key_exists('menu_type', $variables)
+    || $variables['menu_name'] === 'main';
+
   foreach ($variables['items'] as &$item) {
-    _hdbt_menu_item_apply_attributes($item);
+    _hdbt_menu_item_apply_attributes($item, $apply_lang_attribute);
   }
 }
 
@@ -432,12 +435,14 @@ function hdbt_preprocess_menu(&$variables) {
  *
  * @param array $item
  *   Menu item.
+ * @param bool $apply_lang_attribute
+ *   Indicates whether we should search for the possible lang attribute.
  */
-function _hdbt_menu_item_apply_attributes(array &$item) {
+function _hdbt_menu_item_apply_attributes(array &$item, $apply_lang_attribute) {
   // Iterate through child menu items.
   if (!empty($item['below'])) {
     foreach ($item['below'] as &$item_below) {
-      _hdbt_menu_item_apply_attributes($item_below);
+      _hdbt_menu_item_apply_attributes($item_below, $apply_lang_attribute);
     }
   }
 
@@ -460,13 +465,31 @@ function _hdbt_menu_item_apply_attributes(array &$item) {
 
   // Handle lang attribute if it's missing from menu item.
   if (
+    $apply_lang_attribute &&
     !$item['attributes']->hasAttribute('lang') &&
     array_key_exists('original_link', $item) &&
-    $item['original_link'] instanceof MenuLinkContent &&
-    !empty($item['original_link']->getOptions()['lang'])
+    $item['original_link'] instanceof MenuLinkContent
   ) {
-    $item['attributes']
-      ->setAttribute('lang', $item['original_link']->getOptions()['lang']);
+    // MenuLinkContent::getEntity() has protected visibility and cannot be used
+    // to directly fetch the entity.
+    $metadata = $item['original_link']->getMetaData();
+
+    if (!empty($metadata['entity_id'])) {
+      $entity_type_manager = Drupal::entityTypeManager();
+      $menu_link_content = $entity_type_manager
+        ->getStorage('menu_link_content')
+        ->load($metadata['entity_id']);
+
+      // Add the possible lang attribute to menu item attributes.
+      if (
+        !empty($menu_link_content) &&
+        $menu_link_content->hasField('lang_attribute') &&
+        !$menu_link_content->get('lang_attribute')->isEmpty()
+      ) {
+        $lang_attribute = $menu_link_content->get('lang_attribute')->value;
+        $item['attributes']->setAttribute('lang', $lang_attribute);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Lang attribute fix
<!-- What problem does this solve? -->

## What was donee
<!-- Describe what was done -->

* [Added fix for the missing lang attribute in main menus.](https://github.com/City-of-Helsinki/drupal-hdbt/commit/67e7779e2addeb150c8bc57edb5ecb7ace0a15b6)

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_lang_attribute_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add "lang" attribute to main menu item in any instance and see that it gets rendered in the markup
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
