### PR TITLE
Remove id to avoid generating duplicate id's...

### DIFF
--- a/templates/block/block--external-menu-block.html.twig
+++ b/templates/block/block--external-menu-block.html.twig
@@ -35,7 +35,7 @@
 {# Render navigation with content from another instance "globally" #}
 {% if use_global_navigation %}
   {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-  <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
+  <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby', 'id') }}>
     {# Label. If not displayed, we still provide it for screen readers. #}
     {% if not configuration.label_display %}
       {% set title_attributes = title_attributes.addClass('visually-hidden') %}


### PR DESCRIPTION
… on all pages when block is used twice for navigation fallback

# UHF-X
<!-- What problem does this solve? -->

We got a siteimprove report that we have duplicate id's on all our pages with the id: `block-external-header-top-navigation` We are using that block twice in code on purpose, to handle mobile and desktop navigations in proper source order.

## What was done
<!-- Describe what was done -->

* The block id was filtered totally off, as it's not being used for anything AFAIK

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_fix_duplicate_id`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check external header top no longer generates any id, thus avoiding duplicate id problems
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] ~This PR has been visually reviewed by a designer (Name of the designer)~

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
