### PR TITLE
Changes other langscheck to if global nav is enabled

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -82,7 +82,7 @@
 
             {% if use_global_navigation %}
               {# Other languages button #}
-              {% include "@hdbt/compon$ent/otherlanguages.twig" with {
+              {% include "@hdbt/component/otherlanguages.twig" with {
                 renderButton: true,
               } %}
             {% endif %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -80,15 +80,15 @@
           <div class="language-wrapper">
             {{ drupal_entity('block', block__language_switcher) }} {# Change language-menu and content in other languages-menu #}
 
-            {% if show_header_language_links_button %}
+            {% if use_global_navigation %}
               {# Other languages button #}
-              {% include "@hdbt/component/otherlanguages.twig" with {
+              {% include "@hdbt/compon$ent/otherlanguages.twig" with {
                 renderButton: true,
               } %}
             {% endif %}
           </div>
           
-          {% if show_header_language_links_button %}
+          {% if use_global_navigation %}
             {{ drupal_entity('block', block__external_header_language_links) }} {# Other languages menu content #}
           {% endif %}
 


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

* Changes otherlangs button and block check to if global navigation is enabled

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X-otherlangs-fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check the otherlangs menu works if global navigation is enabled
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
