### PR TITLE
UHF-6829: Removed dropdown button when there is no children.

### DIFF
--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -54,7 +54,7 @@
       {% endif %}
 
       {% set link_id = 'aria-id-' ~ random() %}
-      {% set item_is_collabsible = (allow_collabsible and (item.is_collapsed or item.is_expanded)) ? true : false %}
+      {% set item_is_collabsible = (allow_collabsible and (item.is_collapsed or item.is_expanded) and has_children) ? true : false %}
 
       {% set item_classes = [
         'menu__item',


### PR DESCRIPTION
# [UHF-6829](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6829)
<!-- What problem does this solve? -->
Removed dropdown button when there is no children.
## What was done
<!-- Describe what was done -->
* Removed dropdown button when there is no children.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6829-dropdown-indicator-fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that menu items without children (enabled/published etc) don't have the dropdown indicator/button.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
