### PR TITLE
Remove lang attribute from li-element in menu

### DIFF
--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -70,7 +70,7 @@
         {% set item_lang = ' lang=' ~ item.attributes.lang ~ '' %}
       {% endif %}
 
-      <li{{ item.attributes.removeAttribute('class').addClass(item_classes) }}>
+      <li{{ item.attributes.removeAttribute('class', 'lang').addClass(item_classes) }}>
         <span class="menu__link-wrapper">
           {% if not item.is_nolink %}
             {% spaceless %}


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

Language attribute was leaking to parent li-element, thus causing the possible screen reader help texts to be in wrong lang.

## What was done
<!-- Describe what was done -->

* li-element no longer has lang-attribute

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_lang_attribute_leak`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that main menu li-element no longer have lang-attributes when the lang attribute is added to link (like in strategia test instance main menu)
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] ~This PR has been visually reviewed by a designer (Name of the designer)~
