### PR TITLE
UHF-6557: Added check around the pager variables that are assigned in…

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1221,9 +1221,13 @@ function hdbt_theme_suggestions_views_infinite_scroll_pager_alter(array &$sugges
  */
 function hdbt_preprocess_views_view(&$variables) {
   // Add pager items per page as a variable.
-  $variables['pager_items_per_page'] = $variables['view']->pager->options['items_per_page'];
+  if ($variables['view']->pager != null) {
+    $variables['pager_items_per_page'] = $variables['view']->pager->options['items_per_page'];
+  }
   // Add total rows as a variable.
-  $variables['total_rows'] = $variables['view']->total_rows;
+  if ($variables['view']->total_rows != null) {
+    $variables['total_rows'] = $variables['view']->total_rows;
+  }
 }
 
 /**

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1221,11 +1221,11 @@ function hdbt_theme_suggestions_views_infinite_scroll_pager_alter(array &$sugges
  */
 function hdbt_preprocess_views_view(&$variables) {
   // Add pager items per page as a variable.
-  if ($variables['view']->pager != null) {
+  if ($variables['view']->pager != NULL) {
     $variables['pager_items_per_page'] = $variables['view']->pager->options['items_per_page'];
   }
   // Add total rows as a variable.
-  if ($variables['view']->total_rows != null) {
+  if ($variables['view']->total_rows != NULL) {
     $variables['total_rows'] = $variables['view']->total_rows;
   }
 }


### PR DESCRIPTION
… views view preprocess

# [UHF-6557](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6557)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed warnings:
  * Warning: Attempt to read property "options" on null in hdbt_preprocess_views_view() (line 1224 of themes/contrib/hdbt/hdbt.theme).
  * Warning: Trying to access array offset on value of type null in hdbt_preprocess_views_view() (line 1224 of themes/contrib/hdbt/hdbt.theme).

## How to install

* Make sure your KYMP instance is up and running on this feature branch.
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6557_district_sub_navigation_and_other_changes`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add for example English translation to Finnish district that has project listing paragraph on content and make sure you don't get any warnings.
* [ ] Check the other PR and follow its instructions.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/461
