### PR TITLE
UHF-7024: Add translated description to header top bar nav for screenreaders

### DIFF
--- a/templates/block/block--external-menu-block--header-top-navigation.html.twig
+++ b/templates/block/block--external-menu-block--header-top-navigation.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+
+{# Render navigation with content from another instance "globally" #}
+{% if use_global_navigation %}
+  <nav role="navigation" aria-label="{{ 'Quick links'|t({}, {'context': 'Header top navigation screen reader name'}) }}"{{ attributes|without('role', 'aria-labelledby', 'id', 'aria-label') }}>
+
+    {# Menu. #}
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </nav>
+{% endif %}

--- a/templates/layout/region--header-top.html.twig
+++ b/templates/layout/region--header-top.html.twig
@@ -13,11 +13,7 @@
  */
 #}
 {% if content %}
-  <div{{attributes.addClass('header-top').setAttribute('id','hdbt-header-top').setAttribute('drupal-hdbt-selector','hdbt-header-top')}}>
-    {% set attributes_id = 'block-hdbt-subtheme-headertopnavigation'|clean_id %}
-    {% set heading_id = attributes_id ~ '-menu'|clean_id %}
-    <nav role="navigation" aria-label="{{ 'Site navigation'|t({}, {'context': 'Screenreader name for top navigation menu'}) }}" id="{{ attributes_id }}">
-      {{ content }}
-    </nav>
+  <div class="header-top">
+    {{ content }}
   </div>
 {% endif %}

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -287,3 +287,7 @@ msgstr "Sulje tietoa muilla kielillä valikko"
 msgctxt "Other languages-navigation"
 msgid "Information in other languages"
 msgstr "Tietoa muilla kielillä"
+
+msgctxt "Header top navigation screen reader name"
+msgid "Quick links"
+msgstr "Pikalinkit"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -284,3 +284,7 @@ msgstr "Stäng Information på andra språk meny"
 msgctxt "Other languages-navigation"
 msgid "Information in other languages"
 msgstr "Information på andra språk"
+
+msgctxt "Header top navigation screen reader name"
+msgid "Quick links"
+msgstr "Snabblänkar"


### PR DESCRIPTION
# [UHF-7024](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7024)
<!-- What problem does this solve? -->

Header top nav (the one with the coronavirus link) does not have an translated and a reasonable name.

## What was done
<!-- Describe what was done -->

* A name was added to the top nav
* To add the name, a new template was created
* The h2 title was moved to aria-label to keep the headings clear from above h1 heading
* Translations were added

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7024_header_top_a11y_name`
* Run `make drush-cr`
* Update translations and empty your cache (from the drupal teardrop)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the top nav has an accessible, translated name
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
