### PR TITLE
Hide header search when global nav is disabled

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -89,12 +89,12 @@
           </div>
 
           {% if use_global_navigation %}
-            {{ drupal_entity('block', block__external_header_language_links) }} {# Other languages menu content #}
-          {% endif %}
+            {# Other languages menu content #}
+            {{ drupal_entity('block', block__external_header_language_links) }}
 
-          {# Header search button and menu #}
-          {# TO-DO remove comment from search include once it is functional #}
-          {% include "@hdbt/component/header-search.twig" %}
+            {# Header search button and menu #}
+            {% include "@hdbt/component/header-search.twig" %}
+          {% endif %}
 
           {{ drupal_entity('block', block__branding_navigation) }} {# Branding menu, aka icon menu #}
 


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Header search does not play nicely when global nav is disabled.
![image](https://user-images.githubusercontent.com/1191667/195508527-38fed443-2bfe-47f1-a189-2f824f996baf.png)

## What was done
<!-- Describe what was done -->

* Header search was removed from html source when global nav is disabled (js was already disabled)

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
  * Disable global nav from your instance `drush pm-uninstall helfi_navigation` (you can later re-enable it with `drush en helfi_navigation`)
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_hide_local_nav_header_search`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that header search does not appear when global nav is disabled
* [ ] Check that header search works when global nav is enabled
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
