### PR TITLE
UHF-X Chat leijuke fix

### DIFF
--- a/templates/block/block--chatleijuke.html.twig
+++ b/templates/block/block--chatleijuke.html.twig
@@ -1,0 +1,3 @@
+{% block content %}
+  {{ content }}
+{% endblock %}


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Added template for the chat leijuke block to prevent printing of the block title.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_chat_leijuke_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the huge whitespace in the bottom of the "Etusivu" instance is gone and "chat leijuke" appears normally
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
