### PR TITLE
UHF-6960 Front page quicklinks

### DIFF
--- a/templates/block/block--external-menu-block-fallback.html.twig
+++ b/templates/block/block--external-menu-block-fallback.html.twig
@@ -32,6 +32,12 @@
  */
 #}
 
+{% if not header_top_navigation_content %}
+  {% set header_top_navigation_content %}
+    {{ drupal_entity('block', 'external_header_top_navigation')}}
+  {% endset %}
+{% endif %}
+
 {% set block_content %}
   {% block content %}
     {{ content }}
@@ -63,7 +69,7 @@
     modifier_class: 'nav-toggle-dropdown--menu',
     description: 'Navigation menu'|t({}, {'context': 'Mobile navigation menu description for screen readers'})
   } %}
-    {% block content%}
+    {% block content %}
       <div class="mega-and-mobilemenu">
 
         {# Render external mega menu block. #}
@@ -75,9 +81,7 @@
         <div class="mmenu__footer js-mmenu__footer">
 
           {% set inside_cssmenu = true %}
-          {% block header_top_navigation %}
-            {{ drupal_entity('block', 'external_header_top_navigation')}}
-          {% endblock header_top_navigation %}
+          {{ header_top_navigation_content }}
 
           <div class="mmenu__logo">
             {% set link_label %}


### PR DESCRIPTION
# [UHF-6960](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6960)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed header top navigation to variable, instead of twig block

## How to install

* Make sure your "Etusivu" instance is up and running on latest `UHF-6960_front_page_quicklinks` branch.
  * `git pull origin UHF-6960_front_page_quicklinks`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6960_front_page_quicklinks`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the header quicklinks gets rendered in to mobile navigation when exploring the mobile width without JS 
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/179
