### PR TITLE
UHF-6525: Add no-js support to sidebar and section menus

### DIFF
--- a/src/scss/06_components/navigation/_sidebar-menu.scss
+++ b/src/scss/06_components/navigation/_sidebar-menu.scss
@@ -57,10 +57,15 @@ $-outline-width: 3px;
   .menu__toggle-button {
     background: transparent;
     border: none;
+    display: none;
     height: 44px;
     padding: 0;
     position: relative;
     width: 44px;
+
+    :where(html.js) & {
+      display: block;
+    }
 
     // Decorative gray box around icon
     &::before {
@@ -120,7 +125,11 @@ $-outline-width: 3px;
 
   // Hides closed menus
   .menu__item--children .menu {
-    display: none;
+    display: block;
+
+    :where(html.js) & {
+      display: none; // By default hide closed menus when js is enabled
+    }
   }
 
   .menu__item--open {
@@ -266,9 +275,12 @@ $-outline-width: 3px;
 
     @include breakpoint(max-width $breakpoint-l) {
       background-color: $color-silver;
-      display: block;
       height: 54px;
       width: 54px;
+
+      :where(html.js) & {
+        display: block;
+      }
     }
 
     &:before {
@@ -279,7 +291,11 @@ $-outline-width: 3px;
 
 .section-navigation__menu-wrapper {
   @include breakpoint(max-width $breakpoint-l) {
-    display: none;
+    display: block;
+
+    :where(html.js) & {
+      display: none;
+    }
   }
 
   .menu__toggle-button:before {


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

We do not support nojs option in our sidebar or section menus atm.

## What was done
<!-- Describe what was done -->

* By changing minor things in css, we can change the default assumption to be open on all sidebar and section nav menus and only close them when we have js option available.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6525_nojs_support`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works in section nav and sidebar nav with and without js
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
