### PR TITLE
UHF-6983: Added published over a year ago tag for news item

### DIFF
--- a/templates/module/helfi-news-item/node--news-item.html.twig
+++ b/templates/module/helfi-news-item/node--news-item.html.twig
@@ -10,6 +10,19 @@
 
     {# Created date and modified date #}
     {% if published_at is not empty %}
+      {% if date(published_at) < date('-365days') %}
+        {% set tag_content %}
+          <span>{{ 'Published over a year ago'|t({}, {'context': 'The helper text before the node published timestamp'}) }}</span>
+        {% endset %}
+        {% embed '@hdbt/misc/tag-list.twig'%}
+          {% block content %}
+            {% include '@hdbt/misc/tag.twig' with {
+              tag: tag_content,
+              color: 'alert'
+            }%}
+            {% endblock content %}
+        {% endembed %}
+      {% endif %}
       <div class="content-date">
         {% set html_published_at = published_at|format_date('custom', 'Y-m-d') ~ 'T' ~ published_at|format_date('custom', 'H:i') %}
         <time datetime="{{ html_published_at }}" class="content-date__datetime content-date__datetime--published">

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -114,6 +114,10 @@ msgctxt "The helper text before the node changed timestamp"
 msgid "Updated over a year ago"
 msgstr "Päivitetty yli vuosi sitten"
 
+msgctxt "The helper text before the node published timestamp"
+msgid "Published over a year ago"
+msgstr "Julkaistu yli vuosi sitten"
+
 msgctxt "The helper text before the social media share buttons"
 msgid "Share"
 msgstr "Jaa"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -110,6 +110,10 @@ msgctxt "The helper text before the node changed timestamp"
 msgid "Updated over a year ago"
 msgstr "Uppdaterad för över ett år sedan"
 
+msgctxt "The helper text before the node published timestamp"
+msgid "Published over a year ago"
+msgstr "Publicerad för över ett år sedan"
+
 msgctxt "The helper text before the social media share buttons"
 msgid "Share"
 msgstr "Dela"


### PR DESCRIPTION
# [UHF-6983](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6983)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added missing "Published over a year ago" tag for news item

## How to install

Test in etusivu intance

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6983-news-published-year-ago-tag`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to some news page and check that the tag isn't visible if the news item is published within a year
* [ ] Edit the nodes published at date to be over a year ago
* [ ] Check the news item again, there should now be a yellow tag visible that says it was published over a year ago
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

