### PR TITLE
UHF-7138: Menu scrollback problem

### DIFF
--- a/src/js/nav-global.js
+++ b/src/js/nav-global.js
@@ -3,17 +3,48 @@ const ToggleWidgets = require('./nav-global/toggle-widgets');
 const NavToggleDropdown = require('./nav-global/nav-toggle-dropdown');
 
 
+
+let scrollP = null;
+function scrollSave() {
+  if (scrollP != null) {
+    console.log('Skipping save');
+  } else {
+    scrollP = document.documentElement.scrollTop || document.body.scrollTop;
+    console.log('Scroll saved:', scrollP);
+  }
+}
+function scrollMove() {
+  if (scrollP != null) {
+    document.documentElement.scrollTop = document.body.scrollTop = scrollP;
+    console.log('Scrolled to:', scrollP, 'resetting now to null');
+    scrollP = null;
+  } else {
+    console.log('Was null, ignoring move');
+  }
+}
+
 /**
  * Init Menus and bind them together so that only one menu is open at a time.
  */
 
 MenuDropdown.init({
+  beforeOpen: () => {
+    scrollSave();
+  },
   onOpen: () => {
+    const scrollP2 = scrollP;
+    scrollP = null;
+    console.log('menu',scrollP2);
     OtherLangsDropdown.close();
     SearchDropdown.close();
     ToggleWidgets.close();
+    scrollP = scrollP2;
+    console.log('restoring from menu to', scrollP);
   },
-  onClose: ToggleWidgets.open
+  onClose: () => {
+    scrollMove();
+    ToggleWidgets.open();
+  }
 });
 
 const OtherLangsDropdown = NavToggleDropdown();
@@ -21,12 +52,24 @@ OtherLangsDropdown.init({
   name: 'Other languages dropdown',
   buttonSelector: '.js-otherlangs-button',
   targetSelector: '#otherlangs',
+  beforeOpen: () => {
+    scrollSave();
+  },
   onOpen: () => {
+    const scrollP2 = scrollP;
+    scrollP = null;
+    console.log('otherlang', scrollP2);
     MenuDropdown.close();
     SearchDropdown.close();
     ToggleWidgets.close();
+    scrollP = scrollP2;
+    console.log('restoring from otherlang to', scrollP);
+
   },
-  onClose: ToggleWidgets.open
+  onClose: () => {
+    scrollMove();
+    ToggleWidgets.open();
+  }
 });
 
 const SearchDropdown = NavToggleDropdown();
@@ -34,22 +77,40 @@ SearchDropdown.init({
   name: 'Search dropdown',
   buttonSelector: '.js-header-search__button',
   targetSelector: '#search',
+  beforeOpen: () => {
+    scrollSave();
+  },
   onOpen: () => {
+    const scrollP2 = scrollP;
+    scrollP = null;
+    console.log('search', scrollP2);
     MenuDropdown.close();
     OtherLangsDropdown.close();
     ToggleWidgets.close();
     window.setTimeout(() => document.querySelector('#search-form')?.focus(), 10); // Delay focus until element is focusable
+    scrollP = scrollP2;
+    console.log('restoring from search to', scrollP);
   },
-  onClose: ToggleWidgets.open
+  onClose: () => {
+    scrollMove();
+    ToggleWidgets.open();
+  }
 });
 
 
 const closeFromOutside = ({ target }) => {
   if (target.closest('.desktop-menu, .header-top') || target.closest('.header') === null) {
+
+    const scrollP2 = scrollP;
+    scrollP = null;
+    console.log('outside', scrollP2);
     MenuDropdown.close();
     OtherLangsDropdown.close();
     SearchDropdown.close();
     ToggleWidgets.open();
+    scrollP = scrollP2;
+    console.log('restoring from outside to', scrollP);
+    scrollMove();
   }
 };
 

--- a/src/js/nav-global/menu.js
+++ b/src/js/nav-global/menu.js
@@ -479,6 +479,9 @@ const MobilePanel = {
     }
   },
   open: function () {
+    if (this.beforeOpen) {
+      this.beforeOpen();
+    }
     this.menu.dataset.target = 'true';
     this.toggleButton.setAttribute('aria-expanded', 'true');
     if (this.onOpen) {
@@ -494,7 +497,7 @@ const MobilePanel = {
     // We should always focus the menu button after toggling the menu
     this.toggleButton.focus();
   },
-  init: function ({ onOpen, onClose }) {
+  init: function ({ beforeOpen, onOpen, onClose }) {
     /**
      * Start the panel after DOM has loaded.
      * Compiled templates need to have reliable access to header and menu elements cloned from Server DOM.
@@ -504,6 +507,7 @@ const MobilePanel = {
       return;
     }
 
+    this.beforeOpen = beforeOpen;
     this.onOpen = onOpen;
     this.onClose = onClose;
     document.addEventListener('DOMContentLoaded', () => {

--- a/src/js/nav-global/nav-toggle-dropdown.js
+++ b/src/js/nav-global/nav-toggle-dropdown.js
@@ -6,6 +6,7 @@ class NavToggleDropdown {
     this.running = false;
     this.targetNode = null;
     this.onOpen = null;
+    this.beforeOpen = null;
   }
   isOpen() {
     return window.location.hash === this.HASH_ID || this.targetNode.dataset.target === 'true';
@@ -20,7 +21,10 @@ class NavToggleDropdown {
     }
   }
   open() {
-    if(this.running) {
+    if (this.running) {
+      if (this.beforeOpen) {
+        this.beforeOpen();
+      }
       this.buttonInstance.setAttribute('aria-expanded', 'true');
       this.targetNode.dataset.target = 'true';
       if (this.onOpen) {
@@ -50,7 +54,7 @@ class NavToggleDropdown {
       this.toggle();
     });
   }
-  init({ name, buttonSelector, targetSelector, onOpen, onClose }) {
+  init({ name, buttonSelector, targetSelector, beforeOpen, onOpen, onClose }) {
     this.name = name;
     this.buttonSelector = buttonSelector;
     this.buttonInstance = document.querySelector(this.buttonSelector);
@@ -63,8 +67,9 @@ class NavToggleDropdown {
       console.warn(`${name} already initiated. Is it included more than once?`);
       return;
     }
-    
+
     this.HASH_ID = targetSelector;
+    this.beforeOpen = beforeOpen;
     this.onOpen = onOpen;
     this.onClose = onClose;
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
# [UHF-7138](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7138)
<!-- What problem does this solve? -->

On a [long page](https://www.hel.fi/fi/paatoksenteko-ja-hallinto/strategia-ja-talous/strategia/kaupunkistrategian-esipuhe) the mobile menu open resetting scroll position to top of page can be frustrating.

## What was done
<!-- Describe what was done -->

* Scroll position is saved when a menu is opened and restored when it's closed.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7138_menu_scrollback_problem`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this scrollback works with all menus and click combinations
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
