### PR TITLE
UHF-7253: Fix error when organization entity is missing

### DIFF
--- a/modules/hdbt_content/hdbt_content.tokens.inc
+++ b/modules/hdbt_content/hdbt_content.tokens.inc
@@ -109,9 +109,8 @@ function hdbt_content_tokens(
       }
       elseif (
         $node->hasField('field_organization') &&
-        isset($node->field_organization) &&
-        $node->field_organization->entity->hasField('field_default_image') &&
-        !$node->field_organization->entity->field_default_image->isEmpty()
+        $node->get('field_organization')?->entity?->hasField('field_default_image') &&
+        !$node->get('field_organization')->entity->get('field_default_image')->isEmpty()
       ) {
         // Use the image from the taxonomy term.
         $taxonomy_term = $node->field_organization->entity;


### PR DESCRIPTION
# [UHF-7253](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7253)

## What was done
* Fixed an error when job listing's organization field was empty.

## How to install

* Make sure your `rekry` instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7253-fix-missing-organization-error`
* Run `make drush-cr`

## How to test
* Before using this branch, you can try to replicate the error.
  * Edit some job listing and remove the organization reference.
  * You should get error when viewing the job listing after saving.
* Change to this branch and reload the page. The job listing page should work as expected.

## Designers review
* [x] This PR does not need designers review