### PR TITLE
UHF-7139: Remove footer top content configuration

### DIFF
--- a/config/install/block.block.footertopnavigationsecond.yml
+++ b/config/install/block.block.footertopnavigationsecond.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.footer-top-navigation-2
+  module:
+    - menu_block_current_language
+  theme:
+    - hdbt
+id: footertopnavigationsecond
+theme: hdbt
+region: footer_top
+weight: 0
+provider: null
+plugin: 'menu_block_current_language:footer-top-navigation-2'
+settings:
+  id: 'menu_block_current_language:footer-top-navigation-2'
+  label: Connect
+  label_display: visible
+  provider: menu_block_current_language
+  level: 1
+  expand_all_items: false
+  depth: 1
+  translation_providers:
+    views: views
+    menu_link_content: menu_link_content
+    default: '0'
+visibility: {  }

--- a/config/install/language/fi/block.block.footertopnavigationsecond.yml
+++ b/config/install/language/fi/block.block.footertopnavigationsecond.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Ota yhteyttä'

--- a/config/install/language/sv/block.block.footertopnavigationsecond.yml
+++ b/config/install/language/sv/block.block.footertopnavigationsecond.yml
@@ -1,0 +1,2 @@
+settings:
+  label: 'Ta kontakt'

--- a/config/install/system.menu.footer-top-navigation-2.yml
+++ b/config/install/system.menu.footer-top-navigation-2.yml
@@ -1,7 +1,7 @@
 langcode: und
 status: true
 dependencies: {  }
-id: footer-top-navigation
-label: 'Footer - Top navigation - First'
+id: footer-top-navigation-2
+label: 'Footer - Top navigation - Second'
 description: 'Top navigation for footer block.'
 locked: false

--- a/modules/hdbt_content/hdbt_content.install
+++ b/modules/hdbt_content/hdbt_content.install
@@ -5,6 +5,9 @@
  * Update hooks for HDBT content and HDBT base theme.
  */
 
+use Drupal\block\Entity\Block;
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * Re-import the default config for the theme.
  */
@@ -147,5 +150,117 @@ function hdbt_content_update_9004() {
       $hdbt_subtheme_heroblock_data['weight'] = -11;
       $hdbt_subtheme_heroblock->setData($hdbt_subtheme_heroblock_data)->save(TRUE);
     }
+  }
+}
+
+/**
+ * Add footer top navigation secondary menu.
+ */
+function hdbt_content_update_9005() {
+  $theme_handler = Drupal::service('theme_handler');
+  $module_handler = Drupal::service('module_handler');
+  $config_factory = \Drupal::configFactory();
+  $config_location = dirname(__FILE__, 3) . '/config/install/';
+
+  if (!$module_handler->moduleExists('helfi_navigation')) {
+    $config_name = 'system.menu.footer-top-navigation-2';
+
+    $filepath = "{$config_location}{$config_name}.yml";
+    if (file_exists($filepath)) {
+      $data = Yaml::parse(file_get_contents($filepath));
+      if (is_array($data)) {
+        $config_factory->getEditable($config_name)->setData($data)->save(TRUE);
+      }
+    }
+  }
+
+
+  // Handle HDBT theme.
+  if ($theme_handler->themeExists('hdbt') && !$module_handler->moduleExists('helfi_navigation')) {
+    $config_name = 'block.block.footertopnavigationsecond';
+
+    $filepath = "{$config_location}{$config_name}.yml";
+    if (file_exists($filepath)) {
+      $data = Yaml::parse(file_get_contents($filepath));
+      if (is_array($data)) {
+        $config_factory->getEditable($config_name)->setData($data)->save(TRUE);
+      }
+    }
+
+    $translations = [
+      'fi' => 'Ota yhteyttä',
+      'sv' => 'Ta kontakt',
+    ];
+
+    hdbt_content_install_block_translations($translations, 'block.block.footertopnavigationsecond');
+
+    $hdbt_footertopblock = $config_factory->getEditable('block.block.footertopblock');
+    $hdbt_footertopblock_data = $hdbt_footertopblock->getRawData();
+    if (!empty($hdbt_footertopblock_data)) {
+      $hdbt_footertopblock->delete();
+    }
+  }
+
+  // Handle HDBT_subtheme theme.
+  if ($theme_handler->themeExists('hdbt_subtheme') && !$module_handler->moduleExists('helfi_navigation')) {
+    $block_configuration = [
+      'id' => 'hdbt_subtheme_footertopnavigationsecond',
+      'plugin' => 'menu_block_current_language:footer-top-navigation-2',
+      'region' => 'footer_top',
+      'settings' => [
+        'id' => 'menu_block_current_language:footer-top-navigation-2',
+        'label' => 'Connect',
+        'label_display' => 'visible',
+        'provider' => 'helfi_navigation',
+        'level' => 1,
+        'depth' => 1,
+        'expand_all_items' => FALSE,
+      ],
+      'langcode' => 'en',
+      'status' => TRUE,
+      'provider' => NULL,
+      'theme' => 'hdbt_subtheme',
+      'visibility' => [],
+      'weight' => 2,
+    ];
+
+    $translations = [
+      'fi' => 'Ota yhteyttä',
+      'sv' => 'Ta kontakt',
+    ];
+
+    hdbt_content_install_block_translations($translations, 'block.block.hdbt_subtheme_footertopnavigationsecond');
+
+    $block = Block::create($block_configuration);
+    $block->save();
+
+    $hdbt_subtheme_footertopblock = $config_factory->getEditable('block.block.hdbt_subtheme_footertopblock');
+    $hdbt_subtheme_footertopblock_data = $hdbt_subtheme_footertopblock->getRawData();
+    if (!empty($hdbt_subtheme_footertopblock_data)) {
+      $hdbt_subtheme_footertopblock->delete();
+    }
+  }
+}
+
+/**
+ * Install block translations.
+ *
+ * @param array $translations
+ *   Array containing translation strings for Finnish and Swedish.
+ * @param string $block_name
+ *   Block name as a string.
+ */
+function hdbt_content_install_block_translations(array $translations, string $block_name) : void {
+  foreach (['fi', 'sv'] as $lang_code) {
+    /** @var \Drupal\language\Config\LanguageConfigOverride $config_translation */
+    $config_translation = \Drupal::languageManager()
+      ->getLanguageConfigOverride($lang_code, $block_name);
+    $config_translation
+      ->setData([
+        'settings' => [
+          'label' => $translations[$lang_code],
+        ],
+      ])
+      ->save();
   }
 }


### PR DESCRIPTION
# UHF-7139 [UHF-7139](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7139)
Remove footer top content configuration and replace it with a real menu on instances that don't use global navigation.

## What was done
* Check if there is footer top content block set and remove it.
* Add new menu called footer top navigation - second.
* Add new menu block to footer that displays the new footer top navigation - second menu contents.

## How to install
* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173)

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173
* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/19
