### PR TITLE
UHF-7126: Run token url through file generator

### DIFF
--- a/modules/hdbt_content/hdbt_content.tokens.inc
+++ b/modules/hdbt_content/hdbt_content.tokens.inc
@@ -48,7 +48,11 @@ function hdbt_content_tokens(
     // Add default og-image as the shareable image.
     if ($theme_handler->themeExists('hdbt')) {
       $theme = $theme_handler->getTheme('hdbt');
-      $default_image = "/{$theme->getPath()}/src/images/og-global.png";
+      /** @var \Drupal\Core\File\FileUrlGeneratorInterface $service */
+      $service = \Drupal::service('file_url_generator');
+      $default_image = $service->generate("{$theme->getPath()}/src/images/og-global.png")
+        ->toString(TRUE)
+        ->getGeneratedUrl();
     }
 
     // Custom token for default-og-image.


### PR DESCRIPTION
# [UHF-7126](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7126)
<!-- What problem does this solve? -->

## How to install

* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7126`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure og default image is still served through proxy asset path. For example https://kymp.docker.so/liikenne-assets/themes/xxxx/og-image.png
