### PR TITLE
UHF-7264: Fixed issue with empty tags appearing when the tag was unpu…

### DIFF
--- a/templates/misc/tag.twig
+++ b/templates/misc/tag.twig
@@ -1,13 +1,15 @@
 {# See available colors from _tags.scss #}
 
-{% if color %}
-  {% set tag_color_class = 'content-tags__tags__tag--' ~ color %}
-{% endif %}
-
-<li class="content-tags__tags__tag {{ tag_color_class }}">
-  {% if addSpan %}
-    <span>{{ tag }}</span>
-  {% else %}
-    {{ tag }}
+{% if tag %}
+  {% if color %}
+    {% set tag_color_class = 'content-tags__tags__tag--' ~ color %}
   {% endif %}
-</li>
+
+  <li class="content-tags__tags__tag {{ tag_color_class }}">
+    {% if addSpan %}
+      <span>{{ tag }}</span>
+    {% else %}
+      {{ tag }}
+    {% endif %}
+  </li>
+{% endif %}


### PR DESCRIPTION
…blished or missing for some other reason

# [UHF-7264](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7264)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Empty tags pills appearing on news items when the tag is unpublished or empty for some reason.
* Fixed this by checking on tag-twig template that the content is not empty before printing.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7264_fix_empty_tag_issue`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] I would recommend using a database dump from production so it is easy to test with content that has tags that are not visible for anonymous user. This is a good example content: https://helfi-etusivu.docker.so/fi/uutiset/kaupunki-mukana-malmin-paivassa-18-toukokuuta
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
