### PR TITLE
UHF-7249: Changed popular services paragraph to use title field if it…

### DIFF
--- a/templates/paragraphs/paragraph--popular-services.html.twig
+++ b/templates/paragraphs/paragraph--popular-services.html.twig
@@ -2,12 +2,12 @@
   {% embed "@hdbt/misc/component.twig" with
     {
       component_classes: [ 'component--popular-services' ],
-      component_title: 'Popular services'|t({}, {'context': 'Popular services paragraph title'}),
+      component_title: content.field_popular_services_title|render ? content.field_popular_services_title : 'Popular services'|t({}, {'context': 'Popular services paragraph title'}),
       component_content_class: 'popular-services',
     }
   %}
       {% block component_content %}
-        {{ content }}
+        {{ content.field_service_items }}
       {% endblock component_content %}
   {% endembed %}
 {% endblock paragraph %}


### PR DESCRIPTION
# [UHF-7249](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7249)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed popular services paragraph template to use the new title field if it has content, if it's empty the title should default to "Popular services"

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7249-popular-services-editable-title`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Create a landing page and add the popular services paragraph to it. As default the title value should be "Popular services" (in what ever language is chosen)
* [x] Save the page and check that the title is rendered correctly
* [x] Edit the title, save it and check that it appears 
* [x] Remove the title completely, it should default to "Popular services"
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/413
