### PR TITLE
UHF-7685: Show message when newslist has now news to list

### DIFF
--- a/templates/paragraphs/paragraph--news-list.html.twig
+++ b/templates/paragraphs/paragraph--news-list.html.twig
@@ -8,9 +8,13 @@
   %}
 		{% block component_content %}
 
-      <ul class="news-listing news-listing--latest-medium-teasers">
-			  {{ content.news_list }}
-      </ul>
+      {% if content.news_list %}
+        <ul class="news-listing news-listing--latest-medium-teasers">
+          {{ content.news_list }}
+        </ul>
+      {% else %}
+        <p class="news-listing news-listing--no-news">{{ 'No related news.'|t({}, {'context': 'When newslist component does not have any news to list'}) }}</p>
+      {% endif %}
 
 			{% set link_title %}
 			  <span class="hds-button__label">{{ 'See all the news'|t({}, {'context' : 'News list paragraph see all news link'}) }}</span>

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -311,3 +311,7 @@ msgstr "Pikalinkit"
 msgctxt "TPR unit daycare distance"
 msgid "Distance"
 msgstr "Etäisyys"
+
+msgctxt "When newslist component does not have any news to list"
+msgid "No related news."
+msgstr "Ei uutisia tästä aiheesta."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -308,3 +308,7 @@ msgstr "Snabblänkar"
 msgctxt "TPR unit daycare distance"
 msgid "Distance"
 msgstr "Distans"
+
+msgctxt "When newslist component does not have any news to list"
+msgid "No related news."
+msgstr "Inga nyheter i ämnet."


### PR DESCRIPTION
# [UHF-7685](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7685)
<!-- What problem does this solve? -->
News listing produces an empty ul-element when there are no news to list. It looks confusing, ugly and causes siteimprove to lose its marbles. 😕 

## What was done
<!-- Describe what was done -->

* An error message `<p>` was added instead of the `<ul>` element when there are no news.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-UHF-7685_no_news`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that newslisting has a message when news are not available
* [x] Check that the message works on all three languages
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* This PR does not need designers review


[UHF-7685]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ