### PR TITLE
UHF-X: Fix list of links item heading level

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -677,6 +677,7 @@ function hdbt_preprocess_paragraph(array &$variables) {
   if ($paragraph_type == 'list_of_links_item') {
     $paragraph_parent = $paragraph->getParentEntity();
     $design = $paragraph_parent->get('field_list_of_links_design')->getString();
+    $variables['list_of_links_paragraph_has_title'] = $paragraph_parent->get('field_list_of_links_title')->getString() ? true : false;
     $variables['list_of_links_design'] = $design;
   }
 

--- a/templates/paragraphs/paragraph--list-of-links-item.html.twig
+++ b/templates/paragraphs/paragraph--list-of-links-item.html.twig
@@ -72,8 +72,8 @@
         ],
         'target': target_new ? '_blank' : null,
       } %}
-      <h3 class="list-of-links__item__title">{{ link(link_title, url, link_attributes) }}</h3>
-
+      {% set titleHeading = list_of_links_paragraph_has_title ? 'h3' : 'h2' %}
+      <{{titleHeading}} class="list-of-links__item__title">{{ link(link_title, url, link_attributes) }}</{{titleHeading}}>
       {% if list_of_links_design == 'without-image' %}
         {% if desc %}
           <div class="list-of-links__item__desc">{{ desc }}</div>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Siteimprove reports mixed heading levels on pages that do not have h2 and contain list-of-links with no title. (h1 --> h3) For example: [Symppis](https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/paihdepalvelut/symppis)

## What was done
<!-- Describe what was done -->

* A check was added to list-of-links for paragraph title that toggles h2 or h3 level for links.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_list_of_links_h_level`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that list of links item heading levels work with and without paragraph title (either h3 or h2)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* This PR does not need designers review
