### PR TITLE
Fixed twig:compile error

### DIFF
--- a/templates/module/helfi_tpr/tpr-content-liftup.html.twig
+++ b/templates/module/helfi_tpr/tpr-content-liftup.html.twig
@@ -1,2 +1,2 @@
 {# Remove this file after siteimprove clears its removal #}
-{% include '@hdbt/module/helfi_tpr/tpr-unit--wide-teaser.html.twig' with { tpr_content_liftup_class = 'tpr-content-liftup-html-twig' }%}
+{% include '@hdbt/module/helfi_tpr/tpr-unit--wide-teaser.html.twig' with { tpr_content_liftup_class: 'tpr-content-liftup-html-twig' }%}


### PR DESCRIPTION
## What was done

At the moment `drush twig:compile` fails with the following error:

![image](https://user-images.githubusercontent.com/771113/212252454-da6957dd-9b05-4d0a-9fba-cee1a3cbf107.png)

## How to test
* [ ] Run `drush twig:compile` without this fix
* [ ] Run `drush twig:compile` with this change.
