### PR TITLE
UHF-X: Fix skipping in accordion heading levels

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -703,16 +703,18 @@ function hdbt_preprocess_paragraph(array &$variables) {
     if ($accordion_has_title) {
       // Remove inaccessible skipping between title level and item level.
       // For example:
-      //   title h3, item h6 --> fixed item h4
-      //   title h2, item h3 --> item h3
-      //   title h3, item h3 --> item h3
-      //   title h5, item h3 --> item h3
+      // title h3, item h6 --> fixed item h4,
+      // title h2, item h3 --> item h3,
+      // title h3, item h3 --> item h3,
+      // title h5, item h3 --> item h3.
       if ($accordion_title_level + 1 < $accordion_item_heading_level) {
         $variables['accordion_item_heading_level'] = $accordion_title_level + 1;
-      } else {
+      }
+      else {
         $variables['accordion_item_heading_level'] = $accordion_item_heading_level;
       }
-    } else {
+    }
+    else {
       $variables['accordion_item_heading_level'] = $accordion_item_heading_level;
     }
   }

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -691,9 +691,12 @@ function hdbt_preprocess_paragraph(array &$variables) {
   // and tell its children the heading level.
   if ($paragraph_type == 'accordion_item') {
     $paragraph_parent = $paragraph->getParentEntity();
-    $accordion_has_title = $paragraph_parent->get('field_accordion_title')->getString() ? TRUE : FALSE;
-    $accordion_title_level = $paragraph_parent->get('field_accordion_title_level')->getString();
-    $accordion_item_heading_level = $paragraph_parent->get('field_accordion_heading_level')->getString();
+    $accordion_has_title = (bool) !$paragraph_parent
+      ->get('field_accordion_title')->isEmpty();
+    $accordion_title_level = $paragraph_parent
+      ->get('field_accordion_title_level')->getString();
+    $accordion_item_heading_level = $paragraph_parent
+      ->get('field_accordion_heading_level')->getString();
 
     // Check if accordion paragraph has a title and set item heading level
     // based on that. If not, use level given by editor.

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -691,8 +691,27 @@ function hdbt_preprocess_paragraph(array &$variables) {
   // and tell its children the heading level.
   if ($paragraph_type == 'accordion_item') {
     $paragraph_parent = $paragraph->getParentEntity();
+    $accordion_has_title = $paragraph_parent->get('field_accordion_title')->getString() ? TRUE : FALSE;
+    $accordion_title_level = $paragraph_parent->get('field_accordion_title_level')->getString();
     $accordion_item_heading_level = $paragraph_parent->get('field_accordion_heading_level')->getString();
-    $variables['accordion_item_heading_level'] = $accordion_item_heading_level;
+
+    // Check if accordion paragraph has a title and set item heading level
+    // based on that. If not, use level given by editor.
+    if ($accordion_has_title) {
+      // Remove inaccessible skipping between title level and item level.
+      // For example:
+      //   title h3, item h6 --> fixed item h4
+      //   title h2, item h3 --> item h3
+      //   title h3, item h3 --> item h3
+      //   title h5, item h3 --> item h3
+      if ($accordion_title_level + 1 < $accordion_item_heading_level) {
+        $variables['accordion_item_heading_level'] = $accordion_title_level + 1;
+      } else {
+        $variables['accordion_item_heading_level'] = $accordion_item_heading_level;
+      }
+    } else {
+      $variables['accordion_item_heading_level'] = $accordion_item_heading_level;
+    }
   }
 
   // Check if the paragraph is a type of image.


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Editors can accidentally cause skipping in heading levels from [h2 to h4 for example](https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/toihin-meille/opiskelijalle-ja-harjoittelijalle#fysioterapian-ja-toimintaterapian-opiskelijat).  This causes screen readers problems and Siteimprove complains about it.

## What was done
<!-- Describe what was done -->

* If accordion paragraph contains a title and the heading level skips numbers between accordion title level and accordion item title levels, use accordion title level +1 as accordion item title level. (in our title h2, item h4 example, item level becomes h3)
* While we could fix item level being lower than title level, it's perfectly valid for screen readers and siteimprove, so lets not try to be too smart in case someone actually needs the functionality.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_accordion_heading_levels`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add bunch of accordions to a page.
* [x] Check that accordions with no paragraph title follow the heading level setting editors have set for accordion items.
* [x] Check that accordions with paragraph title fix their levels like this:

<table role="table">
  <thead>
    <tr>
      <th></th>
      <th></th>
      <th colspan="5">item</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th></th>
      <th></th>
      <th>h2</th>
      <th>h3</th>
      <th>h4</th>
      <th>h5</th>
      <th>h6</th>
    </tr>
    <tr>
      <td rowspan="5">title</td>
      <td>h2</td>
      <td>h2</td>
      <td>h3</td>
      <td>h3 (fix)</td>
      <td>h3 (fix)</td>
      <td>h3 (fix)</td>
    </tr>
    <tr>
      <th>h3</th>
      <td>h2</td>
      <td>h3</td>
      <td>h4</td>
      <td>h4 (fix)</td>
      <td>h4 (fix)</td>
    </tr>
    <tr>
      <th>h4</th>
      <td>h2</td>
      <td>h3</td>
      <td>h4</td>
      <td>h5</td>
      <td>h5 (fix)</td>
    </tr>
    <tr>
      <th>h5</th>
      <td>h2</td>
      <td>h3</td>
      <td>h4</td>
      <td>h5</td>
      <td>h6</td>
    </tr>
    <tr>
      <th>h6</th>
      <td>h2</td>
      <td>h3</td>
      <td>h4</td>
      <td>h5</td>
      <td>h6</td>
    </tr>
  </tbody>
</table>




* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* This PR does not need designers review
