### PR TITLE
UHF-X: Fix TPR-unit wide teaser heading level

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit--wide-teaser.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit--wide-teaser.html.twig
@@ -24,10 +24,10 @@
 
   <div class="content-liftup__text">
     <div class="content-liftup__text__container">
-      <h3 class="content-liftup__title">
+      <h2 class="content-liftup__title">
         {% set link_attributes = { 'class': [ 'content-liftup__link', ], } %}
         {{ link(entity.label, unit_url, link_attributes) }}
-      </h3>
+      </h2>
       <div class="content-liftup__info">
         {% if content.address|render %}
           <div class="content-liftup__info-row content-liftup__info-row--address">


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
TPR-unit wide teaser has heading level `<h3>` even when it's it's on [a page with no `<h2>` on it](https://www.hel.fi/en/decision-making/contact-us/helsinki-info/helsinki-infos-contact-information).

## What was done
<!-- Describe what was done -->

* Heading level was set to H2

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_tpr_unit_wide_teaser_heading_level`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that heading level is H2 for "Sisältönosto" components
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* This PR does not need designers review
