### PR TITLE
UHF-7343: Added missing translations for the service channel

### DIFF
--- a/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -72,7 +72,7 @@
 
   {% if content.call_charge_info|render %}
     <div class="service-channel__call_charge">
-      <span class="service-channel__call_charge-label">{{ 'Call charge'|t }}:</span>
+      <span class="service-channel__call_charge-label">{{ 'Call charge'|t({}, {'context': 'TPR service channel call charge info'}) }}:</span>
       {{ content.call_charge_info }}
     </div>
   {% endif %}

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -331,3 +331,7 @@ msgstr "Kirjaudu"
 msgctxt "Profile information-menu open button text for screen readers"
 msgid "You are logged in as @display_name. Open profile information menu."
 msgstr "Olet kirjautuneena käyttäjänimellä @display_name. Sulje käyttäjä-valikko."
+
+msgctxt "TPR service channel call charge info"
+msgid "Call charge"
+msgstr "Puhelumaksu"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -328,3 +328,7 @@ msgstr "Logga in"
 msgctxt "Profile information-menu open button text for screen readers"
 msgid "You are logged in as @display_name. Open profile information menu."
 msgstr "Du är inloggad som @display_name. Stäng profilinformationsmenyn."
+
+msgctxt "TPR service channel call charge info"
+msgid "Call charge"
+msgstr "Samtalsavgift"


### PR DESCRIPTION
# [UHF-7343](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7343)
One text copy was missing a translation for Finnish and Swedish in the service channel component.

## What was done

* Added the translations for "call charge".

## How to install

* Make sure your asuminen instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7343_Service-channel-translations`
* Run `drush locale:check && drush locale:update`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the "call charge" text copy is translated in the service channel component on both Finnish and Swedish pages. Example page with the service channel https://helfi-asuminen.docker.so/fi/asuminen/omistusasunnot/hitas-asunnon-myyminen

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-7343]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ