### PR TITLE
UHF-X: add event list library back that was removed my mistake.

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -146,3 +146,12 @@ nav-global:
   dependencies:
     - hdbt/global-styling
     - hdbt/nav-toggle
+
+event-list:
+  version: 1.x
+  js:
+    dist/js/linkedevents.min.js: {}
+  dependencies:
+    - core/drupalSettings
+    - core/jquery
+    - core/drupal


### PR DESCRIPTION
Event list library was removed inadvertently when fixing conflicts :( This PR adds it back.

If you need to test more check instruction from this PR:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/508