### PR TITLE
UHF-X: add better location field value check

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1519,7 +1519,7 @@ function hdbt_preprocess_paragraph__event_list(&$variables) {
       $eventUrl = $linkedEvents->getEventsRequest($params, $settings['field_event_count']);
       $settings['events_api_url'] = $eventUrl;
       $settings['request_url'] = $eventUrl;
-      if ($paragraph->get('field_event_location')->first()->getValue()['value']) {
+      if (!empty($paragraph->get('field_event_location')->getValue()) && $paragraph->get('field_event_location')->first()->getValue()['value']) {
         $settings['places'] = $linkedEvents->getPlaceslist($eventUrl);
       }
     }


### PR DESCRIPTION
<!-- What problem does this solve? -->
Fix related to [UHF-8070](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8070) changes.

## What was done
<!-- Describe what was done -->

* Add better location field value check. Location field was recently added to events paragraph. If node hasn't been saved after that boolean field value doesn't exist.

## How to install

* Make sure SOTE instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X-location-field-value-check`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that these pages work without unexpected error:

- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset/musiikkiryhmat-palvelukeskuksessa
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset/mielen-hyvinvoinnin-ryhmat-palvelukeskuksessa
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset/peliryhmat-palvelukeskuksessa
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset/vertaistukiryhmat-palvelukeskuksessa


* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-8070]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ