### PR TITLE
UHF-X: Results title in unit search with 0 results

### DIFF
--- a/templates/views/views-view--unit-search.html.twig
+++ b/templates/views/views-view--unit-search.html.twig
@@ -55,10 +55,12 @@
   {{ attachment_before }}
 
   <div class="unit-search__results">
-    <span class="unit-search__count-container">
-      <span class="unit-search__count">{{ total_rows ? total_rows : 0 }}</span>
-      {% trans with {'context': 'Unit search count'}%}result{% plural total_rows %}results{% endtrans %}
-    </span>
+    {% if total_rows %}
+      <span class="unit-search__count-container">
+        <span class="unit-search__count">{{ total_rows }}</span>
+        {% trans with {'context': 'Unit search count'}%}result{% plural total_rows %}results{% endtrans %}
+      </span>
+    {% endif %}
 
     {{ rows }}
   

--- a/templates/views/views-view--unit-search.html.twig
+++ b/templates/views/views-view--unit-search.html.twig
@@ -56,7 +56,7 @@
 
   <div class="unit-search__results">
     <span class="unit-search__count-container">
-      <span class="unit-search__count">{{ total_rows }}</span>
+      <span class="unit-search__count">{{ total_rows ? total_rows : 0 }}</span>
       {% trans with {'context': 'Unit search count'}%}result{% plural total_rows %}results{% endtrans %}
     </span>
 

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -1,5 +1,6 @@
 msgid ""
 msgstr ""
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
 msgid "Change cookie settings"
 msgstr "Muokkaa evästeasetuksia"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -1,5 +1,6 @@
 msgid ""
 msgstr ""
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
 msgid "Change cookie settings"
 msgstr "Ändra inställningarna för cookies"


### PR DESCRIPTION
The title over the results in the Private general upper secondary school search [on this page](https://helfi-kasko.docker.so/en/childhood-and-education/general-upper-secondary-education/general-upper-secondary-schools) says just " results" with a small "r" if there are no results.

## What was done
* Removed the "x results" when there are no results.

## How to install

* Make sure your Kasko instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-x_Unit-search-no-results-title`
* Run `make drush-cr`
* Run `make shell` and then `drush locale:check && drush locale:update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the "x results" text is not there when the unit search doesn't have results.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
