### PR TITLE
UHF-X: Add missing quotes around html attribute values

### DIFF
--- a/templates/component/accordion.twig
+++ b/templates/component/accordion.twig
@@ -14,7 +14,7 @@
 
 <div class="accordion__wrapper helfi-accordion-item" data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
   <span class="is-hidden" id="{{ toggle_button_labelledby_id }}">{{ 'Toggle element: '|t({}, {'context': 'The helper text for toggle accordion visibility button'}) }}{{ heading|default('Missing heading'|t) }}</span>
-  <{{ heading_level|default('h2') }} class="accordion-item__header helfi-accordion__header" id="{{ labelledby_id }}" data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
+  <{{ heading_level|default('h2') }} class="accordion-item__header helfi-accordion__header" data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
     <button class="accordion-item__button accordion-item__button--toggle helfi-accordion__header__button" aria-expanded="true" aria-controls="{{ controlled_content_id }}" aria-labelledby="{{ toggle_button_labelledby_id }}">
       {% if heading_icon %}
         <div class="accordion-item__icon">

--- a/templates/component/accordion.twig
+++ b/templates/component/accordion.twig
@@ -14,7 +14,7 @@
 
 <div class="accordion__wrapper helfi-accordion-item" data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
   <span class="is-hidden" id="{{ toggle_button_labelledby_id }}">{{ 'Toggle element: '|t({}, {'context': 'The helper text for toggle accordion visibility button'}) }}{{ heading|default('Missing heading'|t) }}</span>
-  <{{ heading_level|default('h2') }} class="accordion-item__header helfi-accordion__header" id={{ labelledby_id }} data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
+  <{{ heading_level|default('h2') }} class="accordion-item__header helfi-accordion__header" id="{{ labelledby_id }}" data-accordion-id="{{heading[0]['#context']['value']|clean_class}}">
     <button class="accordion-item__button accordion-item__button--toggle helfi-accordion__header__button" aria-expanded="true" aria-controls="{{ controlled_content_id }}" aria-labelledby="{{ toggle_button_labelledby_id }}">
       {% if heading_icon %}
         <div class="accordion-item__icon">

--- a/templates/misc/nav-toggle-button.twig
+++ b/templates/misc/nav-toggle-button.twig
@@ -23,7 +23,7 @@
   </div>
 
   {# Slightly more accessible js enhanced menu button #}
-  <button class="nav-toggle__button {{ button_modified }} {{ js_target }}" aria-expanded="false" aria-controls={{ controls }}>
+  <button class="nav-toggle__button {{ button_modified }} {{ js_target }}" aria-expanded="false" aria-controls="{{ controls }}">
     <span class="nav-toggle__label {{ label_modified }} nav-toggle__label--open">{{ menu_open }}</span>
     <span class="nav-toggle__label {{ label_modified }} nav-toggle__label--close">{{ menu_close }}</span>
   </button>

--- a/templates/navigation/menu--external-header-language-links.html.twig
+++ b/templates/navigation/menu--external-header-language-links.html.twig
@@ -38,7 +38,7 @@
 
     {% set item_lang = '' %}
     {% if item.attributes.lang %}
-      {% set item_lang = ' lang=' ~ item.attributes.lang ~ '' %}
+      {% set item_lang %} lang="{{ item.attributes.lang }}"{% endset %}
     {% endif %}
 
     {% set item_title %}

--- a/templates/navigation/menu--external-menu--fallback.html.twig
+++ b/templates/navigation/menu--external-menu--fallback.html.twig
@@ -68,8 +68,13 @@
           ]%}
           <li{{ item.attributes.addClass(item_classes) }}>
 
+            {% set item_lang = '' %}
+            {% if item.attributes.lang %}
+              {% set item_lang %} lang="{{ item.attributes.lang }}"{% endset %}
+            {% endif %}
+
             {% set item_title %}
-              <span class="mmenu__link__text"{{ (item.attributes.lang) ? ' lang=' ~ item.attributes.lang : '' }}>{{ item.title }}</span>
+              <span class="mmenu__link__text"{{ item_lang }}>{{ item.title }}</span>
             {% endset %}
 
             {% if not item.is_nolink %}

--- a/templates/navigation/menu--external-menu--mega-menu.html.twig
+++ b/templates/navigation/menu--external-menu--mega-menu.html.twig
@@ -61,12 +61,15 @@
             'megamenu__item--level-' ~ (level + 1),
           ]%}
 
-          {% set langAttribute = item.attributes.lang %}
+          {% set item_lang = '' %}
+          {% if item.attributes.lang %}
+            {% set item_lang %} lang="{{ item.attributes.lang }}"{% endset %}
+          {% endif %}
 
           <li{{ item.attributes.removeAttribute('class').removeAttribute('lang').addClass(item_classes) }}>
 
             {% set item_title %}
-              <span class="megamenu__link__text"{{ (langAttribute) ? ' lang='~langAttribute : '' }}>{{item.title}}</span>
+              <span class="megamenu__link__text"{{ item_lang }}>{{item.title}}</span>
             {% endset %}
 
             {% if not item.is_nolink %}
@@ -76,7 +79,7 @@
                 {% if icon_name %}
                   {% set item_title %}
                     {% include '@hdbt/misc/icon.twig' with {icon: icon_name, class: 'megamenu__link__icon'} %}
-                    <span class="megamenu__link__text"{{ (langAttribute) ? ' lang='~langAttribute : '' }}>{{ item.title }}</span>
+                    <span class="megamenu__link__text"{{ item_lang }}>{{ item.title }}</span>
                   {% endset %}
                 {% endif %}
 

--- a/templates/navigation/menu--mobile.html.twig
+++ b/templates/navigation/menu--mobile.html.twig
@@ -57,8 +57,13 @@
 
           <li{{ item.attributes.addClass(item_classes) }}>
 
+            {% set item_lang = '' %}
+            {% if item.attributes.lang %}
+              {% set item_lang %} lang="{{ item.attributes.lang }}"{% endset %}
+            {% endif %}
+
             {% set item_title %}
-              <span class="mmenu__link__text"{{ (item.attributes.lang) ? ' lang=' ~ item.attributes.lang : '' }}>{{ item.title }}</span>
+              <span class="mmenu__link__text"{{ item_lang }}>{{ item.title }}</span>
             {% endset %}
 
             {% set item_title = item.title %}

--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -68,7 +68,7 @@
 
       {% set item_lang = '' %}
       {% if item.attributes.lang %}
-        {% set item_lang = ' lang=' ~ item.attributes.lang ~ '' %}
+        {% set item_lang %} lang="{{ item.attributes.lang }}"{% endset %}
       {% endif %}
 
       <li{{ item.attributes.removeAttribute('class', 'lang').addClass(item_classes) }}>

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -48,7 +48,7 @@
           </li>
         </ul>
       {% else %}
-        <button type="button" disabled title="{{ 'Go to previous page number'|t({}, {'context': 'Pagination previous page link title'}) }} {{ current - 1 }}" class='hds-button hds-pagination__button-prev'>
+        <button type="button" disabled title="{{ 'Go to previous page number'|t({}, {'context': 'Pagination previous page link title'}) }} {{ current - 1 }}" class="hds-button hds-pagination__button-prev">
           {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'angle-left'} %}
           <span aria-hidden="true" class="hds-pagination__button-prev-label">{{ items.previous.text|default('Previous'|t({}, {'context': 'Pagination previous page link text'})) }}</span>
         </button>
@@ -109,7 +109,7 @@
           </li>
         </ul>
       {% else %}
-        <button type="button" disabled title="{{ 'Go to next page number'|t({}, {'context': 'Pagination next page link title'}) }} {{ current + 1 }}" class='hds-button hds-pagination__button-next'>
+        <button type="button" disabled title="{{ 'Go to next page number'|t({}, {'context': 'Pagination next page link title'}) }} {{ current + 1 }}" class="hds-button hds-pagination__button-next">
           <span aria-hidden="true" class="hds-pagination__button-next-label">{{ items.next.text|default('Next'|t({}, {'context': 'Pagination next page link text'})) }}</span>
           {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'angle-right'} %}
         </button>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Siteimprove was complaining about duplicate ids on a page: https://www.hel.fi/fi/paatoksenteko-ja-hallinto/sisallonhallinta/sivujen-rakentaminen-drupalissa/sivupohjat-ja-niiden-valinta/perussivu/esimerkki

It turned out that we had a id that leaked its contents as it did not have quotes arounds its empty value.

## What was done
<!-- Describe what was done -->

* Checked for other such problems and found potential problems in multiple places.
* The places where attributes were set without quotes were fixed in this PR 
* The id did not have contents because the variable was misnamed, this was fixed

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_fix_html_attributes_missing_quotes`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the new accordions still work
* [x] Check that menu links with lang attribute still work
* [x] Check that pager still works
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

