### PR TITLE
UHF-5047: Cookie content blocker on TPR unit maps

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1262,6 +1262,12 @@ function hdbt_preprocess_field(&$variables) {
         $item['content']['#url']->setOption('attributes', $attributes);
       }
       break;
+
+    case 'service_map_embed':
+      $url_parts = parse_url($variables['items'][0]['content']['iframe']['#attributes']['src']);
+      $variables['map_service_url'] = $url_parts['scheme'] . "://" . $url_parts['host'];
+      $variables['privacy_policy_url'] = _hdbt_eu_cookie_compliance_get_privacy_policy_url();
+      break;
   }
 }
 
@@ -1358,6 +1364,9 @@ function hdbt_preprocess_tpr_unit(&$variables) {
 
   // Add current Unit Url to variable.
   $variables['unit_url'] = !$entity->isNew() ? $entity->toUrl('canonical') : NULL;
+
+  // Add cookie compliance JS to unit pages since they have maps.
+  $variables['#attached']['library'][] = 'hdbt/embedded-content-cookie-compliance';
 }
 
 /**

--- a/templates/module/helfi_tpr/field--service-map-embed.html.twig
+++ b/templates/module/helfi_tpr/field--service-map-embed.html.twig
@@ -1,4 +1,3 @@
-{{ element[0]['iframe'] }}
 {% set link_url = element[0]['link']['#attributes']['href'] %}
 {% set link_attributes = {
   'class': [
@@ -7,4 +6,27 @@
   ],
   'target': '_blank',
 } %}
+{% set iframe_attributes = element[0]['iframe']['#attributes'] %}
+
+{% include '@hdbt/misc/embedded-content-cookie-compliance.twig' with {
+  media_url: iframe_attributes['src'],
+  media_id: element['#object'].id.value,
+  media_service_url: map_service_url,
+  privacy_policy_url: privacy_policy_url,
+} %}
+
+{% set drupal_settings = {
+  '#attached': {
+    'drupalSettings': {
+      'embedded_media_attributes': {
+        (element['#object'].id.value): {
+          'src': iframe_attributes['src'],
+          'title': iframe_attributes['title'],
+          'type': 'map',
+        }
+      }
+    }
+  }
+} %}
+{{ drupal_settings }}
 {{ link(element[0]['link']['#value'], link_url, link_attributes) }}


### PR DESCRIPTION
# [UHF-5047](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5047)
The cookie content blocker didn't work on TPR unit pages.

## What was done
* Use the cookie content blocker template also on TPR unit maps.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-5047_TPR-unit-map-cookies`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check for example this page: https://helfi-kasko.docker.so/en/childhood-and-education/daycare-aada. It should have a map and it's not visible unless cookies are accepted.
* [x] Check that all links (cookie settings page, links to external page) in the cookie content blocker work.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-5047]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ