### PR TITLE
UHF-7960: Get translated value for photographer if it exists.

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -344,7 +344,13 @@ function _hdbt_preprocess_image_caption(array &$variables, string $entity_type, 
       $entity->{$image}->entity?->hasField('field_photographer') &&
       !$entity->{$image}->entity->field_photographer->isEmpty()
     ) {
-      $photographer = $entity->{$image}->entity->field_photographer->value;
+      // Get translated photographer text if available.
+      if ($entity->{$image}->entity->hasTranslation($variables['current_langcode'])) {
+        $photographer = $entity->{$image}->entity->getTranslation($variables['current_langcode'])->field_photographer->value;
+      }
+      else {
+        $photographer = $entity->{$image}->entity->field_photographer->value;
+      }
 
       // If both caption and photographer exists, use targeted translation
       // for the caption and photographer. Otherwise set only photographer as


### PR DESCRIPTION
# [UHF-7960](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7960)
In the image caption, the photographer text is taken from the default language even though there is a translation available. Example of the issue: https://www.hel.fi/fi/uutiset/pormestari-vartiainen-tapasi-new-yorkin-pormestarin-ja-osallistuu-yhdysvaltojen.

## What was done
<!-- Describe what was done -->

* If it exists, get the translated photographer value.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7960_Photographer-info-wrong-translation`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Find (or easier to add by yourself) a news item that has a main image with a caption and photographer field filled in the image media entity. Check that the photographer field is also translated and create a translation in same language for the news item.
* [x] Check that the photographer field is taking the correct translation.
* [x] Check that default language is used if the photographer field doesn't have translation for the current language.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-7960]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/572