### PR TITLE
UHF-X: Remove aria-haspopup from dropdown menu

### DIFF
--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -108,7 +108,6 @@
               aria-expanded="{{ aria_expanded }}"
               aria-controls="{{ menu_aria_controls }}"
               aria-labelledby="{{ link_id }}"
-              aria-haspopup="true"
               class="menu__toggle-button">
               {% include '@hdbt/misc/icon.twig' with {icon: 'angle-down', class: 'menu__toggle-button-icon'} %}
             </button>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
As WAI-ARIA spec has changed to limit the usage of this attribute only to role="menu", we got recommendation from Siteimprove Tero P to stop using this previously recommended practise.

Check #dev-helfi-hds channel in slack for [more info](https://helsinkicity.slack.com/archives/C0370RQ48CR/p1678952230417919).

## What was done
<!-- Describe what was done -->

* The `aria-haspopup` attribute was removed as recommended by experts

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_remove_aria_haspopup`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the `aria-haspopup` was removed properly
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review