### PR TITLE
UHF-8090 UI lang fix

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Template\Attribute;
 use Drupal\helfi_api_base\Environment\Project;
@@ -32,7 +33,7 @@ function hdbt_preprocess(&$variables): void {
   $variables['koro'] = hdbt_get_settings('koro');
   $variables['theme_color'] = hdbt_get_settings('theme_color');
   $variables['image_placeholder'] = hdbt_get_settings('default_icon');
-  $language = Drupal::languageManager()->getCurrentLanguage();
+  $language = Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
   $variables['current_langcode'] = $language->getId();
   $variables['current_language'] = $language->getName();
 


### PR DESCRIPTION
# [UHF-8090](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8090)
Content was shown based on interface language instead of content language

## What was done
Changed getCurrentLanguage method to fetch content language instead of interface language

* This thing was fixed

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8090_ui_lang_fix`
* Run `make drush-cr`

## How to test
Check the etusivu-pr


## Other PRs

The etusivu 8090 pr

[UHF-8090]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ