### PR TITLE
UHF-0000 embedded content cookie blocker lang fixes

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -34,6 +34,11 @@ function hdbt_preprocess(&$variables): void {
   $language = Drupal::languageManager()->getCurrentLanguage();
   $variables['current_langcode'] = $language->getId();
   $variables['current_language'] = $language->getName();
+  $variables['primary_languages'] = [
+    'fi',
+    'en',
+    'sv',
+  ];
 
   // Toggle between global and local navigation in twig templates.
   $variables['use_global_navigation'] = \Drupal::moduleHandler()

--- a/src/scss/06_components/pages/_cookie-compliance.scss
+++ b/src/scss/06_components/pages/_cookie-compliance.scss
@@ -126,12 +126,13 @@
       max-width: 400px; // To avoid too long buttons.
 
       @include breakpoint($breakpoint-m) {
-        margin-inline-start: $spacing;
+        margin-left: $spacing;
         margin-top: 0;
       }
 
       &:first-child {
-        margin: 0;
+        margin-left: 0;
+        margin-top: 0;
       }
     }
   }

--- a/templates/media/media--hel-map.html.twig
+++ b/templates/media/media--hel-map.html.twig
@@ -42,6 +42,10 @@
   privacy_policy_url: privacy_policy_url,
 } %}
 
+{% if current_langcode not in primary_languages %}
+  {% set link = link|merge({'#attributes': {'lang': 'en', 'dir': 'ltr' }}) %}
+{% endif %}
+
 {% set drupal_settings = {
   '#attached': {
     'drupalSettings': {

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -1,4 +1,7 @@
-<div class="embedded-content-cookie-compliance media-{{ media_id }}">
+{% if current_langcode not in primary_languages %}
+  {% set lang_attr = 'lang=en' %}
+{% endif %}
+<div class="embedded-content-cookie-compliance media-{{ media_id }}" {{ lang_attr }} dir="ltr">
   <div class="message">
     {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'alert-circle-fill'} %}
     <h2>{{ 'Content cannot be displayed'|t }}</h2>

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -1,5 +1,6 @@
 {% if current_langcode not in primary_languages %}
   {% set lang_attr = 'lang=en' %}
+  {% set dir_attr = 'dir=ltr' %}
 {% endif %}
 <div class="embedded-content-cookie-compliance media-{{ media_id }}" {{ lang_attr }} dir="ltr">
   <div class="message">

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -2,7 +2,7 @@
   {% set lang_attr = 'lang=en' %}
   {% set dir_attr = 'dir=ltr' %}
 {% endif %}
-<div class="embedded-content-cookie-compliance media-{{ media_id }}" {{ lang_attr }} dir="ltr">
+<div class="embedded-content-cookie-compliance media-{{ media_id }}" {{ lang_attr }} {{ dir_attr }}>
   <div class="message">
     {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'alert-circle-fill'} %}
     <h2>{{ 'Content cannot be displayed'|t }}</h2>

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -1,9 +1,6 @@
-{% if current_langcode not in primary_languages %}
-  {% set lang_attr = 'lang=en' %}
-  {% set dir_attr = 'dir=ltr' %}
-{% endif %}
-<div class="embedded-content-cookie-compliance media-{{ media_id }}" {{ lang_attr }} {{ dir_attr }}>
-  <div class="message">
+{% set alternative_language = current_langcode not in primary_languages %}
+<div class="embedded-content-cookie-compliance media-{{ media_id }}">
+  <div class="message" {{ alternative_language ? create_attribute({'lang': 'en', 'dir': 'ltr'}) }}>
     {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'alert-circle-fill'} %}
     <h2>{{ 'Content cannot be displayed'|t }}</h2>
     <p>

--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -5,9 +5,12 @@
   {% endif %}
 
   {% if 'data-is-external' in attributes|keys %}
+    {% if current_langcode not in primary_languages %}
+      {% set lang_attr = 'lang=en' %}
+    {% endif %}
     {% set external_link_id = 'hdbt-link-' ~ random() %}
     {% set attribute_icon %} <span class="link__type link__type--external" aria-labelledby="{{ external_link_id }}"></span>
-    <span class="is-hidden" id="{{ external_link_id }}">{{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }}</span>{%- endset %}
+    <span class="is-hidden" id="{{ external_link_id }}" {{ lang_attr }}>({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
   {% endif %}
 
   {% if 'data-protocol' in attributes|keys and attributes['data-protocol'] != 'false'%}

--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -1,5 +1,6 @@
 {% spaceless %}
 
+  {% set alternative_language = current_langcode not in primary_languages %}
   {% if 'data-selected-icon' in url.options.attributes|keys %}
     {% set selected_icon -%}{% include '@hdbt/misc/icon.twig' ignore missing with {icon: url.options.attributes['data-selected-icon']} only %}{%- endset %}
   {% endif %}
@@ -7,14 +8,22 @@
   {% if 'data-is-external' in attributes|keys %}
     {% set external_link_id = 'hdbt-link-' ~ random() %}
     {% set attribute_icon %} <span class="link__type link__type--external" aria-labelledby="{{ external_link_id }}"></span>
-    <span class="is-hidden" id="{{ external_link_id }}">({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
+    <span class="is-hidden" id="{{ external_link_id }}" {{ alternative_language ? create_attribute({'lang': 'en', 'dir': 'ltr'}) }}>({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
   {% endif %}
 
   {% if 'data-protocol' in attributes|keys and attributes['data-protocol'] != 'false'%}
     {% if attributes['data-protocol'] == 'tel' %}
-      {% set attribute_icon %} <span class="link__type link__type--tel" aria-label="({{ 'Link starts a phone call'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.'}) }})"></span>{%- endset %}
+      {% set tel_aria_id = 'tel-' ~ random() %}
+      {% set attribute_icon %}
+        <span class="link__type link__type--tel" aria-labelledby="{{ tel_aria_id }}"></span>
+        <span id="{{ tel_aria_id }}" class="is-hidden" {{ alternative_language ? create_attribute({'lang': 'en', 'dir': 'ltr'}) }}>({{ 'Link starts a phone call'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.'}) }})</span>
+      {%- endset %}
     {% elseif attributes['data-protocol'] == 'mailto' %}
-      {% set attribute_icon %} <span class="link__type link__type--mailto" aria-label="({{ 'Link opens default mail program'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.'}) }})"></span>{%- endset %}
+      {% set email_aria_id = 'email-' ~ random() %}
+      {% set attribute_icon %}
+        <span class="link__type link__type--mailto" aria-labelledby="{{ email_aria_id }}"></span>
+        <span id="{{ email_aria_id }}" class="is-hidden" {{ alternative_language ? create_attribute({'lang': 'en', 'dir': 'ltr'}) }}>({{ 'Link opens default mail program'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.'}) }})</span>
+      {%- endset %}
     {% endif %}
   {% endif %}
 

--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -5,12 +5,9 @@
   {% endif %}
 
   {% if 'data-is-external' in attributes|keys %}
-    {% if current_langcode not in primary_languages %}
-      {% set lang_attr = 'lang=en' %}
-    {% endif %}
     {% set external_link_id = 'hdbt-link-' ~ random() %}
     {% set attribute_icon %} <span class="link__type link__type--external" aria-labelledby="{{ external_link_id }}"></span>
-    <span class="is-hidden" id="{{ external_link_id }}" {{ lang_attr }}>({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
+    <span class="is-hidden" id="{{ external_link_id }}">({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
   {% endif %}
 
   {% if 'data-protocol' in attributes|keys and attributes['data-protocol'] != 'false'%}

--- a/templates/module/helfi_tpr/field--service-map-embed.html.twig
+++ b/templates/module/helfi_tpr/field--service-map-embed.html.twig
@@ -6,6 +6,11 @@
   ],
   'target': '_blank',
 } %}
+
+{% if current_langcode not in primary_languages %}
+  {% set link = link|merge({'#attributes': {'lang': 'en', 'dir': 'ltr' }}) %}
+{% endif %}
+
 {% set iframe_attributes = element[0]['iframe']['#attributes'] %}
 
 {% include '@hdbt/misc/embedded-content-cookie-compliance.twig' with {


### PR DESCRIPTION
# UHF-0000
<!-- What problem does this solve? -->
The embedded content blocker doesn't need to support RTL languages as it's displayed in English.

## What was done
<!-- Describe what was done -->

* Reverted the added RTL support
* Wrapper the embedded content cookie blocker screen `dir` and `lang` attributes.
* Added `primary_languages` variable to be available in all templates.
* Added `dir` and `lang` attributes and switched `aria-label` to `aria-labelledby` in the external link, telephone and email fields (part of [UHF-8089](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8089)).

## How to install

* Make sure your etusivu instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_embedded_content-cookie-blocker-lang-fixes`
* Run `npm run build` inside hdbt theme.
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the cookie content blocker over remote videos or maps follows LTR and has English language attribute and `dir=ltr` on all languages except fi, sv and en.
* [ ] Check that telephone and email field doesn't use aria-label anymore and that there is `lang` and `dir` attributes in the screen reader texts.


[UHF-8089]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ