### PR TITLE
UHF-8290 getCurrentLanguage parameters

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -984,7 +984,7 @@ function hdbt_preprocess_paragraph(array &$variables): void {
  *   Variables array.
  */
 function _hdbt_set_site_information(array &$variables) {
-  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $language_id = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
 
   // Set site_name as variable.
   $site_config = \Drupal::config('system.site');


### PR DESCRIPTION
_hdbt_set_site_information is called in hdbt_preprocess_region and hdbt_preprocess_block. Must use TYPE_CONTENT as parameter

