### PR TITLE
UHF-7568 fix theme path issue

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -696,6 +696,9 @@ function hdbt_preprocess_paragraph(array &$variables): void {
   $paragraph = $variables['paragraph'];
   $paragraph_type = $paragraph->getType();
 
+  // Set theme path variable for paragraphs as well.
+  $variables['theme_path'] = _hdbt_get_theme_path();
+
   // Check if the paragraph is a type of list of links item
   // and tell it its parents design.
   if ($paragraph_type == 'list_of_links_item') {

--- a/templates/paragraphs/paragraph--calculator.html.twig
+++ b/templates/paragraphs/paragraph--calculator.html.twig
@@ -31,7 +31,7 @@
           'families_home_services_client_fee',
         ] %}
 
-          <script src="/themes/contrib/hdbt/dist/js/{{calculator_name}}.min.js"></script>
+          <script src="{{ theme_path }}/dist/js/{{calculator_name}}.min.js"></script>
           <script>
             document.addEventListener('DOMContentLoaded', (event) => {
               const clean = window.helfi_calculator.{{calculator_name}}('{{ helfi_calculator_id }}', drupalSettings.{{calculator_name}});


### PR DESCRIPTION
# [UHF-7568](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7568)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed calculators not working with proxy.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7568_fix_theme_path_issue`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that calculators work still after the changes in hdbt.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-7568]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ