### PR TITLE
UHF-8089 Switch aria-label to aria-labelledby in mobile menu

### DIFF
--- a/src/js/nav-global/menu.js
+++ b/src/js/nav-global/menu.js
@@ -112,36 +112,15 @@ function externalLinkIcon() {
 externalLinkIcon.ICONS = {
   mailto: {
     class: 'link__type link__type--mailto',
-    text: Drupal.t(
-      'Link opens default mail program',
-      {},
-      {
-        context:
-          'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.',
-      },
-    ),
+    aria_id: 'aria-mailto-link-label',
   },
   tel: {
     class: 'link__type link__type--tel',
-    text: Drupal.t(
-      'Link starts a phone call',
-      {},
-      {
-        context:
-          'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.',
-      },
-    ),
+    aria_id: 'aria-tel-link-label',
   },
   external: {
     class: 'link__type link__type--external',
-    text: Drupal.t(
-      'Link leads to external service',
-      {},
-      {
-        context:
-          'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.',
-      },
-    ),
+    aria_id: 'aria-external-link-label',
   },
 };
 
@@ -178,7 +157,7 @@ const MobilePanel = {
           lang="{{attributes.lang}}"
         {{/hasLang}}
 
-        >{{name}}</span>{{#externalLinkIcon}} <span class="{{class}}" aria-label="({{text}})"></span>{{/externalLinkIcon}}</a>
+        >{{name}}</span>{{#externalLinkIcon}} <span class="{{class}}" aria-labelledby="{{aria_id}}"></span>{{/externalLinkIcon}}</a>
         {{>sub_tree}}
       </div>
       ${document.querySelector('.js-mmenu__footer')?.outerHTML}
@@ -213,7 +192,7 @@ const MobilePanel = {
             lang="{{attributes.lang}}"
           {{/hasLang}}
 
-          >{{name}}</span>{{#externalLinkIcon}} <span class="{{class}}" aria-label="({{text}})"></span>{{/externalLinkIcon}}
+          >{{name}}</span>{{#externalLinkIcon}} <span class="{{class}}" aria-labelledby="{{aria_id}}"></span>{{/externalLinkIcon}}
           </a>
           {{#button}}
             <button class="mmenu__forward " value={{id}}><span class="visually-hidden">{{openSubMenuTranslation}} {{name}}</span></button>

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -61,6 +61,9 @@
     <js-placeholder token="{{ placeholder_token }}">
   </head>
   <body{{ attributes }}>
+    <span class="is-hidden" id="aria-external-link-label" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>
+    <span class="is-hidden" id="aria-tel-link-label" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link starts a phone call'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.'}) }})</span>
+    <span class="is-hidden" id="aria-mailto-link-label" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link opens default mail program'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.'}) }})</span>
     {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.


### PR DESCRIPTION
# [UHF-8089](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8089)
<!-- What problem does this solve? -->
aria-label should be changed to aria-labelledby.

## What was done
<!-- Describe what was done -->
* Changed to use aria-labelledby in the mobile menu
* Added hidden spans with labels to the top of the page for external, tel and mailto links. Now they can be used wherever needed, for example in the mobile menu.
* Some other existing "Link leads to external service" spans are not touched yet in this since they are being edited same time in another branch.

## How to install

* Make sure your etusivu instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8089_Mobile-menu-external-link-aria-labels`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the screen reader reads the external, tel and mailto links correctly from the mobile menu.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

## Other PRs
This needs to be merged first: https://github.com/City-of-Helsinki/drupal-hdbt/pull/588.


[UHF-8089]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ