### PR TITLE
UHF-7853: Notification components accessibility

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1547,3 +1547,21 @@ function hdbt_preprocess_paragraph__school_search(array &$variables): void {
     $variables['#attached']['drupalSettings']['helfi_school_search']['cookie_privacy_url'] = $privacyUrl->toString();
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function hdbt_preprocess_node__announcement(array &$variables) {
+  $type = $variables['node']->get('field_announcement_type')->value;
+
+  $type_label = match($type) {
+    'alert' => t('Alert'),
+    'attention' => t('Attention'),
+    default => t('Notification')
+  };
+
+  $close_label = t('Close');
+
+  $variables['type_label'] = $type_label;
+  $variables['close_label'] =  $close_label;
+}

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1563,5 +1563,5 @@ function hdbt_preprocess_node__announcement(array &$variables) {
   $close_label = t('Close');
 
   $variables['type_label'] = $type_label;
-  $variables['close_label'] =  $close_label;
+  $variables['close_label'] = $close_label;
 }

--- a/templates/content/node--announcement--default.html.twig
+++ b/templates/content/node--announcement--default.html.twig
@@ -8,7 +8,7 @@
 
 {% set link = content.field_announcement_link[0] %}
 
-<div class="announcement js-announcement {{ block_modifier }} container" data-uuid="{{ node.uuid.value }}">
+<section aria-label={{ type_label }} class="announcement js-announcement {{ block_modifier }} container" data-uuid="{{ node.uuid.value }}">
   <div class="announcement__container">
     <div class="announcement__content">
       {% if content.body|render != null %}
@@ -23,7 +23,7 @@
       {% endif %}
     </div>
     <button type="button" class="announcement__close js-announcement__close--disabled" aria-labelledby="announcement__close__aria-label">
-      <span id="announcement__close__aria-label" class="is-hidden">{{ "Close announcement"|t }}</span>
+      <span id="announcement__close__aria-label" class="is-hidden">{{ [close_label, type_label|lower]|join(" ") }}</span>
     </button>
   </div>
-</div>
+</section>

--- a/templates/misc/status-messages.html.twig
+++ b/templates/misc/status-messages.html.twig
@@ -50,7 +50,7 @@
   <section data-drupal-messages aria-label="{{ 'Notification'|t }}" class="{{ section_classes|without('messages-list')|join(' ') }}" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
     {% set is_message_with_title = status_headings[type] %}
     {% set is_message_with_icon = type in ['error', 'default', 'warning', 'success'] %}
-    <div role="contentinfo" aria-labelledby="{{ title_ids[type] }}" class="{{ classes|without('messages-list__item')|join(' ') }}">
+    <div class="{{ classes|without('messages-list__item')|join(' ') }}">
       {% if is_message_with_title or is_message_with_icon %}
         {% if is_message_with_title %}
           <div class="hds-notification__label" role="heading" aria-level="2">


### PR DESCRIPTION
# [UHF-7853](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7853)
Some accessibiity work for announcement and status message components

## What was done
* Add preprocess hook too expose accessibility-related variables to announcements template
* Implement accessibiity fixes to announcement and status message templates

## How to install

* Boot up an instance of your choice
* Get this branch. `composer require drupal/hdbt:dev-UHF-7853-notification-components-accessibility` 

## How to test
* Create 3 instances of announcements (/node/add/announcement) and select a different type for each of them. Make sure that all have "Show on all pages" option checked.
* After you save the last of them, Drupal should redirect you to the announcement's node page. On this page you should see:
  * All the announcements you created
  * Drupal's status message informing you that that you have just published an announcement

Check for these things: 

In the Drupal's status message: 
* Root container should no longer have `role=contentinfo` or `aria-labelledby` attributes

In the announcement component:
* Root container should now be a `section` element with an `aria-label` informing the use of the announcement's type
* Close button `aria label` should now read `Close [announcement type]` instead of being a static `Close announcement`

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)



[UHF-7853]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ