### PR TITLE
UHF-8215: Add tag container class to news list paragraph

### DIFF
--- a/templates/misc/tag-list.twig
+++ b/templates/misc/tag-list.twig
@@ -4,7 +4,7 @@
   {% set type_class = 'content-tags__tags--static' %}
 {% endif %}
 
- <section class="content-tags"  aria-labelledby='content-tags__label'>
+<section class="content-tags {{ tag_container_class }}"  aria-labelledby='content-tags__label'>
   <span id='content-tags__label' class='is-hidden' {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
     {{ 'Tags'|t({}, {'context': 'Label for screen reader software users explaining that this is a list of tags related to this page.'}) }}
   </span>

--- a/templates/paragraphs/paragraph--news-list.html.twig
+++ b/templates/paragraphs/paragraph--news-list.html.twig
@@ -9,7 +9,7 @@
     {% block component_tags %}
       {% include "@hdbt/misc/news-tags.twig" with 
         {
-          container_classes: ['component__tags'],
+          tag_container_class: 'component__tags',
           tags: content.field_helfi_news_groups,
           neighbourhoods: content.field_helfi_news_tags,
           groups: content.field_helfi_news_neighbourhoods


### PR DESCRIPTION
# [UHF-8215](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8215)

Fix missing class from news list paragraph

[UHF-8215]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ