### PR TITLE
UHF-0000: Reduced duplicate code on external, tel and mail links

### DIFF
--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -5,23 +5,20 @@
   {% endif %}
 
   {% if 'data-is-external' in attributes|keys %}
-    {% set external_link_id = 'hdbt-link-' ~ random() %}
-    {% set attribute_icon %} <span class="link__type link__type--external" aria-labelledby="{{ external_link_id }}"></span>
-    <span class="is-hidden" id="{{ external_link_id }}" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>{%- endset %}
+    {% set attribute_icon %}
+      <span class="link__type link__type--external" aria-labelledby="aria-external-link-label"></span>
+    {%- endset %}
   {% endif %}
 
   {% if 'data-protocol' in attributes|keys and attributes['data-protocol'] != 'false'%}
     {% if attributes['data-protocol'] == 'tel' %}
-      {% set tel_aria_id = 'tel-' ~ random() %}
       {% set attribute_icon %}
-        <span class="link__type link__type--tel" aria-labelledby="{{ tel_aria_id }}"></span>
-        <span id="{{ tel_aria_id }}" class="is-hidden" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link starts a phone call'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.'}) }})</span>
+        <span class="link__type link__type--tel" aria-labelledby="aria-tel-link-label"></span>
       {%- endset %}
     {% elseif attributes['data-protocol'] == 'mailto' %}
       {% set email_aria_id = 'email-' ~ random() %}
       {% set attribute_icon %}
-        <span class="link__type link__type--mailto" aria-labelledby="{{ email_aria_id }}"></span>
-        <span id="{{ email_aria_id }}" class="is-hidden" {{ alternative_language ? create_attribute({'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir}) }}>({{ 'Link opens default mail program'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.'}) }})</span>
+        <span class="link__type link__type--mailto" aria-labelledby="aria-mailto-link-label"></span>
       {%- endset %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
# UHF-0000
<!-- What problem does this solve? -->
There is now  common `<span>` elements for the screen readers to read when a link takes to external page, opens a phone call or the default mail program. These weren't yet used in some cases.

## What was done
<!-- Describe what was done -->

* Switched the `aria-labelledby` attributes in `helfi-link.html.twig` to refer the common span elements.

## How to install

* Make sure your etusivu instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_Refactor-external-links`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add some external link, telephone field and email field. Check that they have the hidden span for screen readers.
* [ ] Translate the page to another language (other than Finnish, Swedish or English). Check that the hidden span for screen readers exists and is in English.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review