### PR TITLE
UHF-X Maintenance mode image

### DIFF
--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -40,7 +40,7 @@
       </main>
     </div>
     <div class="maintenance-page__illustration-container">
-      <img src="https://hel.fi/etusivu-assets/themes/contrib/hdbt/src/images/illustration_error_page_404.svg" alt="" class="maintenance-page__illustration" width="379" height="566" />
+      <img src="https://hel.fi/etusivu-assets/themes/contrib/hdbt/src/images/illustration_maintenance_mode_page.svg" alt="" class="maintenance-page__illustration" width="379" height="566" />
     </div>
   {% endblock container_content %}
 {% endembed %}

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -40,7 +40,7 @@
       </main>
     </div>
     <div class="maintenance-page__illustration-container">
-      <img src="{{ theme_path }}/src/images/illustration_maintenance_mode_page.svg" alt="" class="maintenance-page__illustration" width="379" height="566" />
+      <img src="https://hel.fi/etusivu-assets/themes/contrib/hdbt/src/images/illustration_error_page_404.svg" alt="" class="maintenance-page__illustration" width="379" height="566" />
     </div>
   {% endblock container_content %}
 {% endembed %}


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Temporarily added hardcoded URL for the maintenance mode page illustration as the azure assets path do not work for maintenance page.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_maintenance_mode_image`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Put the site in maintenance mode and check that the illustration works on maintenance mode
