### PR TITLE
UHF-7113 Hyphenopoly preprocess false

### DIFF
--- a/dist/js/hyphenopoly_settings.min.js
+++ b/dist/js/hyphenopoly_settings.min.js
@@ -1,1 +1,1 @@
-document.addEventListener("DOMContentLoaded",(function(){Hyphenopoly.config({require:{fi:"yhdyssanahirviö",sv:"informationssäkerhetskampanj",en:"antidisestablishmentarianism"},setup:{selectors:{".hyphenate":{}}}})}));
+document.addEventListener("DOMContentLoaded",(function(){Hyphenopoly.config({require:{fi:"yhdyssanahirviö",sv:"informationssäkerhetskampanj"},setup:{selectors:{".hyphenate":{}}}})}));

--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -161,5 +161,9 @@ hyphenopoly:
   version: 5.x
   header: true
   js:
-    dist/js/hyphenopoly_settings.min.js: {}
-    dist/js/hyphenopoly/Hyphenopoly_Loader.js: {}
+    dist/js/hyphenopoly_settings.min.js: {
+      preprocess: false
+    }
+    dist/js/hyphenopoly/Hyphenopoly_Loader.js: {
+      preprocess: false
+    }


### PR DESCRIPTION
# [UHF-7113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed hyphenopoly library js-files to preprocess false value.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7113_hyphenopoly_fixes`
* Run `make drush-cr`
* We need to test that the hyphenopoly works with Drupal JS aggregation turned on so we need to do the following:
  * Make sure that you have the aggregation turned on. Comment these lines from local.settings.php file if they are not already:
    * `$config['system.performance']['css']['preprocess'] = 0;`
    * `$config['system.performance']['js']['preprocess'] = 0;`
  * Edit the `hyphenopoly_settings.js` file and change the `'fi'` value to `FORCEHYPHENOPOLY`.
  * Compile the theme styles `nvm use && npm i && npm run build`
  * Clear the caches from project root `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure that the h1 titles are now hyphenated in Finnish using the hyphenopoly library.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-7113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ