### PR TITLE
UHF-X: Fixed typo on news page tag listing element that prevented news tags being rendered

### DIFF
--- a/templates/module/helfi-news-item/node--news-item.html.twig
+++ b/templates/module/helfi-news-item/node--news-item.html.twig
@@ -82,7 +82,7 @@
     {# Tags #}
     {% include "@hdbt/misc/news-tags.twig" with
       {
-        tags: content.news_item_tags,
+        tags: content.field_news_item_tags,
         neighbourhoods: content.field_news_neighbourhoods,
         groups: content.field_news_groups,
       }


### PR DESCRIPTION
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed typo on news page tag listing element that prevented news tags being rendered

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_news_tags_not_displaying_correctly_in_news_page`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to edit any news page and add it some "News tags" category tags. Make sure that they are visible on the page after saving.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
