### PR TITLE
UHF-8431: Missing comma separator on address

### DIFF
--- a/src/scss/06_components/pages/_service-channel.scss
+++ b/src/scss/06_components/pages/_service-channel.scss
@@ -145,6 +145,16 @@
   @include pseudo-icon-replace('envelope');
 }
 
+.service-channel__address {
+  .address > span {
+    display: block;
+  }
+
+  .comma {
+    display: none;
+  }
+}
+
 .service-channel__phone,
 .service-channel__email {
   margin-top: $spacing;

--- a/src/scss/06_components/pages/_service-channel.scss
+++ b/src/scss/06_components/pages/_service-channel.scss
@@ -65,7 +65,7 @@
     text-indent: -9999px;
     width: 24px;
 
-    &:after {
+    &::after {
       @include pseudo-icon(null, $spacing-and-half, $color-black);
       left: 0;
       position: absolute;
@@ -113,35 +113,35 @@
   }
 }
 
-.service-channel--email .service-channel__type:after {
+.service-channel--email .service-channel__type::after {
   @include pseudo-icon-replace('glyph-at');
 }
 
-.service-channel--sms .service-channel__type:after {
+.service-channel--sms .service-channel__type::after {
   @include pseudo-icon-replace('mobile');
 }
 
-.service-channel--telephone .service-channel__type:after {
+.service-channel--telephone .service-channel__type::after {
   @include pseudo-icon-replace('phone');
 }
 
-.service-channel--printable_form .service-channel__type:after {
+.service-channel--printable_form .service-channel__type::after {
   @include pseudo-icon-replace('document');
 }
 
-.service-channel--webpage .service-channel__type:after {
+.service-channel--webpage .service-channel__type::after {
   @include pseudo-icon-replace('globe');
 }
 
-.service-channel--chat .service-channel__type:after {
+.service-channel--chat .service-channel__type::after {
   @include pseudo-icon-replace('speechbubble-text');
 }
 
-.service-channel--local .service-channel__type:after {
+.service-channel--local .service-channel__type::after {
   @include pseudo-icon-replace('location');
 }
 
-.service-channel--mail .service-channel__type:after {
+.service-channel--mail .service-channel__type::after {
   @include pseudo-icon-replace('envelope');
 }
 
@@ -208,13 +208,13 @@
       display: flex;
       margin-top: 0;
 
-      &:after {
+      &::after {
         content: '|';
         margin: 0 $spacing;
       }
 
       &:last-child {
-        &:after {
+        &::after {
           content: '';
         }
       }

--- a/src/scss/06_components/pages/_unit.scss
+++ b/src/scss/06_components/pages/_unit.scss
@@ -54,6 +54,10 @@
     }
   }
 
+  .unit__contact-row--address .comma {
+    display: none;
+  }
+
   .unit__contact-row--email a {
     word-break: break-all;
   }
@@ -343,11 +347,6 @@
 
     .address {
       display: inline;
-
-      .address-line1::after,
-      .address-line2::after {
-        content: ',';
-      }
     }
   }
 
@@ -464,11 +463,6 @@
 
       // Align the address to center with the arrow and the title.
       margin-top: 2px;
-    }
-
-    .address-line1::after,
-    .address-line2::after {
-      content: ',';
     }
 
     p:first-child {

--- a/src/scss/06_components/paragraphs/_content-liftup.scss
+++ b/src/scss/06_components/paragraphs/_content-liftup.scss
@@ -155,11 +155,6 @@ $-info-row-icon-size: $spacing-and-half;
   .content-liftup__info-row__title::before {
     @include pseudo-icon('location', $spacing-and-half, currentColor);
   }
-
-  .address-line1::after,
-  .address-line2::after {
-    content: ',';
-  }
 }
 
 .content-liftup__info-row--opening-hours {

--- a/src/scss/06_components/paragraphs/_content-liftup.scss
+++ b/src/scss/06_components/paragraphs/_content-liftup.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 $-content-liftup-aspect-ratio-mobile: 2.3;
 $-content-liftup-aspect-ratio-desktop: 1.5;
@@ -6,12 +6,12 @@ $-info-row-line-height: 26px;
 $-info-row-icon-size: $spacing-and-half;
 
 .content-liftup {
-  --info-row__gap-size: #{$spacing-quarter};
+  --info-row--gap-size: #{$spacing-quarter};
   border: 1px solid $color-black;
   position: relative;
 
   @include breakpoint($breakpoint-m) {
-    --info-row__gap-size: #{$spacing-half};
+    --info-row--gap-size: #{$spacing-half};
     display: flex; // image and other content in same row
     min-height: 400px; // Defined by design specs
   }
@@ -123,7 +123,7 @@ $-info-row-icon-size: $spacing-and-half;
 .content-liftup__info-row {
   @include font('body');
 
-  --margin-size: calc(#{$-info-row-icon-size} + var(--info-row__gap-size));
+  --margin-size: calc(#{$-info-row-icon-size} + var(--info-row--gap-size));
   margin-left: var(--margin-size);
 
   & + & {
@@ -137,7 +137,7 @@ $-info-row-icon-size: $spacing-and-half;
   &::before {
     margin-bottom: ($-info-row-line-height - $-info-row-icon-size) * 0.5; // Center icon on row
     margin-left: calc( -1 * var(--margin-size));
-    margin-right: var(--info-row__gap-size);
+    margin-right: var(--info-row--gap-size);
   }
 }
 
@@ -166,7 +166,7 @@ $-info-row-icon-size: $spacing-and-half;
 .content-liftup__read-more {
   @include font('button');
   display: flex; // force arrow to stay on same line
-  margin-left: calc(#{$-info-row-icon-size} + var(--info-row__gap-size));
+  margin-left: calc(#{$-info-row-icon-size} + var(--info-row--gap-size));
   padding-bottom: $spacing-half;
   padding-top: $spacing;
 

--- a/src/scss/06_components/paragraphs/_map.scss
+++ b/src/scss/06_components/paragraphs/_map.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 $-map-aspect-ratio-desktop: math.div(16, 9);
 $-map-aspect-ratio-mobile: 1;

--- a/src/scss/06_components/paragraphs/_map.scss
+++ b/src/scss/06_components/paragraphs/_map.scss
@@ -5,10 +5,6 @@ $-map-aspect-ratio-mobile: 1;
 
 .component--map {
   background-color: $color-silver-light;
-
-  .address-line1::after {
-    content: ',';
-  }
 }
 
 .unit .component--map {

--- a/templates/misc/address-plain.html.twig
+++ b/templates/misc/address-plain.html.twig
@@ -36,7 +36,7 @@
  * @ingroup themeable
  */
 #}
-<p class="address" translate="no">
+<span class="address" translate="no">
   {% if given_name or family_name %}
     <span class="given-name">{{ given_name }} {{ family_name }}</span>
   {% endif %}
@@ -44,13 +44,13 @@
     <span class="organization">{{ organization }}</span>
   {% endif %}
   {% if address_line1 %}
-    <span class="address-line1">{{ address_line1 }}, </span>
+    <span class="address-line1">{{ address_line1 }}<span class="comma">, </span></span>
   {% endif %}
   {% if address_line2 %}
-    <span class="address-line2">{{ address_line2 }}</span>
+    <span class="address-line2">{{ address_line2 }}<span class="comma">, </span></span>
   {% endif %}
   {% if dependent_locality.code %}
-    <span class="dependent-locality-code">{{ dependent_locality.code }}</span>
+    <span class="dependent-locality-code">{{ dependent_locality.code }}<span class="comma">, </span></span>
   {% endif %}
   {% if postal_code or administrative_area.code %}
     <span class="postal-code">{{ postal_code }} {{ administrative_area.code }}</span>
@@ -58,4 +58,4 @@
   {% if locality.code %}
     <span class="locality">{{ locality.code }}</span>
   {% endif %}
-</p>
+</span>

--- a/templates/misc/address-plain.html.twig
+++ b/templates/misc/address-plain.html.twig
@@ -44,7 +44,7 @@
     <span class="organization">{{ organization }}</span>
   {% endif %}
   {% if address_line1 %}
-    <span class="address-line1">{{ address_line1 }}</span>
+    <span class="address-line1">{{ address_line1 }}, </span>
   {% endif %}
   {% if address_line2 %}
     <span class="address-line2">{{ address_line2 }}</span>

--- a/templates/misc/tag-list.twig
+++ b/templates/misc/tag-list.twig
@@ -4,8 +4,10 @@
   {% set type_class = 'content-tags__tags--static' %}
 {% endif %}
 
-<section class="content-tags {{ tag_container_class }}"  aria-labelledby='content-tags__label'>
-  <span id='content-tags__label' class='is-hidden' {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+{% set content_tags_id = 'hdbt-content_tags_id-' ~ random() %}
+
+<section class="content-tags {{ tag_container_class }}"  aria-labelledby="{{ content_tags_id }}">
+  <span id="{{ content_tags_id }}" class="is-hidden" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
     {{ 'Tags'|t({}, {'context': 'Label for screen reader software users explaining that this is a list of tags related to this page.'}) }}
   </span>
   <ul class="content-tags__tags {{ type_class }}">

--- a/templates/module/helfi_tpr/field--tpr-service-channel--address.html.twig
+++ b/templates/module/helfi_tpr/field--tpr-service-channel--address.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Template for the 'plain' address formatter in TPR service channels.
+ *
+ * Get the variables from `content` and massage the variables to a suitable
+ * format for the address-plain.html.twig.
+ */
+#}
+{% for item in items %}
+  {% set locality = { 'code': item.content.locality } %}
+  {% set dependent_locality = { 'code': item.content.dependent_locality } %}
+  {% set administrative_area = { 'code': item.content.administrative_area } %}
+
+  {% include '@hdbt/misc/address-plain.html.twig' with {
+    given_name: item.content.given_name,
+    family_name: item.content.family_name,
+    organization: item.content.organization,
+    address_line1: item.content.address_line1,
+    address_line2: item.content.address_line2,
+    dependent_locality: dependent_locality,
+    postal_code: item.content.postal_code,
+    administrative_area: administrative_area,
+    locality: locality,
+  } %}
+{% endfor %}

--- a/templates/module/helfi_tpr/field--tpr-service-channel--address.html.twig
+++ b/templates/module/helfi_tpr/field--tpr-service-channel--address.html.twig
@@ -8,18 +8,18 @@
  */
 #}
 {% for item in items %}
-  {% set locality = { 'code': item.content.locality } %}
-  {% set dependent_locality = { 'code': item.content.dependent_locality } %}
-  {% set administrative_area = { 'code': item.content.administrative_area } %}
+  {% set dependent_locality = { 'code': item.content.dependent_locality['#value'] } %}
+  {% set administrative_area = { 'code': item.content.administrative_area['#value'] } %}
+  {% set locality = { 'code': item.content.locality['#value'] } %}
 
   {% include '@hdbt/misc/address-plain.html.twig' with {
-    given_name: item.content.given_name,
-    family_name: item.content.family_name,
-    organization: item.content.organization,
-    address_line1: item.content.address_line1,
-    address_line2: item.content.address_line2,
+    given_name: item.content.given_name['#value'],
+    family_name: item.content.family_name['#value'],
+    organization: item.content.organization['#value'],
+    address_line1: item.content.address_line1['#value'],
+    address_line2: item.content.address_line2['#value'],
+    postal_code: item.content.postal_code['#value'],
     dependent_locality: dependent_locality,
-    postal_code: item.content.postal_code,
     administrative_area: administrative_area,
     locality: locality,
   } %}


### PR DESCRIPTION
# [UHF-8431](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8431)
<!-- What problem does this solve? -->
TPR Unit listing was missing comma separator on the address info

## What was done
<!-- Describe what was done -->

* Added commas to all possible places in address twig
* Removed commas from CSS that were causing double comma
* Hide commas from places where they're not supposed to be used (when the address is multiline)

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8431_Fix_missing_comma`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Unit address has comma separator on TPR Unit listings 
(e.g. `/fi/kasvatus-ja-koulutus/varhaiskasvatus/varhaiskasvatus-paivakodissa/etsi-kunnallisia-paivakoteja`)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/582


[UHF-8431]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ