### PR TITLE
UHF-8443: Make sure image entity is loaded in correct language

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1080,7 +1080,9 @@ function _hdbt_set_image_style(array &$variables, string $entity_type, string $i
     /** @var \Drupal\file\FileInterface $file */
     $file = $entity->{$image}->entity;
 
-    // Make sure we load the correct translation.
+    // Make sure we load the correct file translation, otherwise
+    // hdbt_preprocess_responsive_image_formatter() will receive an empty
+    // 'altered_image_style' value for translated media entities.
     if ($file->hasTranslation($variables['current_langcode'])) {
       $file = $file->getTranslation($variables['current_langcode']);
     }

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1128,7 +1128,6 @@ function hdbt_preprocess_responsive_image_formatter(&$variables): void {
     $variables['responsive_image']['#height'],
     $variables['responsive_image'],
   );
-  $x = 1;
 }
 
 /**

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1082,7 +1082,7 @@ function _hdbt_set_image_style(array &$variables, string $entity_type, string $i
 
     // Make sure we load the correct translation.
     if ($file->hasTranslation($variables['current_langcode'])) {
-      $file = $entity->{$image}->entity->getTranslation($variables['current_langcode']);
+      $file = $file->getTranslation($variables['current_langcode']);
     }
     // Set altered_image_style variable based on modified image style
     // for the responsive image preprocesses.

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1077,9 +1077,16 @@ function _hdbt_set_image_style(array &$variables, string $entity_type, string $i
     $entity->{$image}->entity->hasField('field_media_image') &&
     !$entity->{$image}->entity->field_media_image->first()->isEmpty()
   ) {
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $entity->{$image}->entity;
+
+    // Make sure we load the correct translation.
+    if ($file->hasTranslation($variables['current_langcode'])) {
+      $file = $entity->{$image}->entity->getTranslation($variables['current_langcode']);
+    }
     // Set altered_image_style variable based on modified image style
     // for the responsive image preprocesses.
-    $entity->{$image}->entity->field_media_image->first()->altered_image_style = $image_style;
+    $file->field_media_image->first()->altered_image_style = $image_style;
   }
 }
 
@@ -1121,6 +1128,7 @@ function hdbt_preprocess_responsive_image_formatter(&$variables): void {
     $variables['responsive_image']['#height'],
     $variables['responsive_image'],
   );
+  $x = 1;
 }
 
 /**


### PR DESCRIPTION
# [UHF-8443](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8443)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8443`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Create a new landing page with diagonal hero image
* [x] Translate the landing page
* [x] Translate the hero media entity
* [x] Make sure both, the original and the translated landing page uses the same image styles for hero image


[UHF-8443]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ