### PR TITLE
UHF-8519: Fixed the map embed URL.

### DIFF
--- a/templates/media/media--hel-map.html.twig
+++ b/templates/media/media--hel-map.html.twig
@@ -31,7 +31,7 @@
  */
 #}
 {% set media_id = media.id() %}
-{% set media_url = media.field_media_hel_map.value.0.uri %}
+{% set media_url = content.field_media_hel_map.0['#iframe']['#attributes']['src'] %}
 {% set media_attributes = media.field_media_hel_map %}
 {% set link = content.field_media_hel_map.0['#link'] %}
 


### PR DESCRIPTION
# [UHF-8519](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8519)
<!-- What problem does this solve? -->

The map component twig template is using wrong version of the map URL.

## What was done
<!-- Describe what was done -->

* Fixed the template to use correct URL variable, which is provided by code that makes sure that the map URL gets the `/embed` to the URL.

## How to install

* Make sure your Kasko instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8519_map-embed-url-fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check the map in https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio/tutustu-ja-hae. The iframe should have embed version and the link under the map should lead to non-embed version.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8519]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ