### PR TITLE
UHF-8485: Fix translation for profile menu accessibility

### DIFF
--- a/translations/fi.po
+++ b/translations/fi.po
@@ -362,7 +362,7 @@ msgstr "Kirjaudu"
 
 msgctxt "Profile information-menu open button text for screen readers"
 msgid "You are logged in as @display_name. Open profile information menu."
-msgstr "Olet kirjautuneena käyttäjänimellä @display_name. Sulje käyttäjä-valikko."
+msgstr "Olet kirjautuneena käyttäjänimellä @display_name. Avaa käyttäjävalikko."
 
 msgctxt "TPR service channel call charge info"
 msgid "Call charge"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -360,7 +360,7 @@ msgstr "Logga in"
 
 msgctxt "Profile information-menu open button text for screen readers"
 msgid "You are logged in as @display_name. Open profile information menu."
-msgstr "Du är inloggad som @display_name. Stäng profilinformationsmenyn."
+msgstr "Du är inloggad som @display_name. Öppna profilinformationsmenyn."
 
 msgctxt "TPR service channel call charge info"
 msgid "Call charge"


### PR DESCRIPTION
# [UHF-8485](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8485)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed translation for sentence "Close menu" to "Open menu" for FI and SV languages. As it is originally on source language.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8485_Translation_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add custom block "`Profile Block`" to region `Header - Branding` on any site instance, or use "drupal-helfi-form-tool" instance where it's already implemented
* [x] Log in to the site, and check screen-reader labels for "Open" and "Close" -actions on the Profile Menu, both FI and SV languages. When menu is closed, it should use phrase "Open profile information menu", and vice versa when menu is open: "Close profile information menu"
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review



[UHF-8485]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ