### PR TITLE
UHF-X: Fix duplicate ids from announcement close button aria-label

### DIFF
--- a/templates/content/node--announcement--default.html.twig
+++ b/templates/content/node--announcement--default.html.twig
@@ -35,8 +35,9 @@
         </div>
       {% endif %}
     </div>
-    <button type="button" class="announcement__close js-announcement__close--disabled" aria-labelledby="announcement__close__aria-label">
-      <span id="announcement__close__aria-label" class="is-hidden">{{ [close_label, type_label|lower]|join(" ") }}</span>
+    {% set announcement_close_labelled_by = "announcement__close__aria-label--" ~ random() %}
+    <button type="button" class="announcement__close js-announcement__close--disabled" aria-labelledby="{{announcement_close_labelled_by}}">
+      <span id="{{announcement_close_labelled_by}}" class="is-hidden">{{ [close_label, type_label|lower]|join(" ") }}</span>
     </button>
   </div>
 </section>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
* When there are more than one notification on a page, their close button aria-labelledby labels have duplicate ids

## What was done
<!-- Describe what was done -->

* IDs were given random identifier to avoid collisions

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_fix_duplicate_announcement_id`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add two or more announcements to your instance, notice that their ids no longer collide
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review