### PR TITLE
UHF-8465: Changed the See content on external site links to include the iframe title for screen readers

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -165,6 +165,13 @@ function hdbt_preprocess_media(&$variables): void {
     $variables['privacy_policy_url'] = helfi_eu_cookie_compliance_get_privacy_policy_url();
     $variables['#attached']['library'][] = 'hdbt/embedded-content-cookie-compliance';
 
+    // If the media in question is a map, get the iframe title for variables.
+    if ($variables['media']->hasField('field_media_hel_map')) {
+      $variables['iframe_title'] = $variables['media']
+        ->get('field_media_hel_map')
+        ->title;
+    }
+
     // If Oembed providers module is installed, get provider URL based on
     // current remote video URL.
     if (

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -13,8 +13,10 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\helfi_api_base\Environment\Project;
+use Drupal\helfi_react_search\LinkedEvents;
 use Drupal\helfi_tpr\Entity\Channel;
 use Drupal\helfi_tpr\Entity\ErrandService;
+use Drupal\helfi_tpr\Entity\Service;
 use Drupal\helfi_tpr\Entity\TprEntityBase;
 use Drupal\helfi_tpr\Entity\Unit;
 use Drupal\image\Entity\ImageStyle;
@@ -24,8 +26,6 @@ use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 use Drupal\views\ViewExecutable;
-use Drupal\helfi_react_search\LinkedEvents;
-use Drupal\helfi_tpr\Entity\Service;
 
 /**
  * Implements hook_preprocess().

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -10,8 +10,8 @@ declare(strict_types = 1);
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Template\Attribute;
+use Drupal\Core\Url;
 use Drupal\helfi_api_base\Environment\Project;
 use Drupal\helfi_tpr\Entity\Channel;
 use Drupal\helfi_tpr\Entity\ErrandService;
@@ -83,7 +83,7 @@ function hdbt_preprocess(&$variables): void {
 /**
  * Retrieve possible theme color palette override.
  */
-function hdbt_get_theme_color_override(): string|false {
+function hdbt_get_theme_color_override(): string|FALSE {
   $color = &drupal_static(__FUNCTION__);
 
   if (!isset($color)) {
@@ -207,9 +207,9 @@ function hdbt_preprocess_media__hel_map(&$variables): void {
  *   Indicates which group does the settings belong to.
  *
  * @return string|null
- *   Returns the desired setting as a string or false.
+ *   Returns the desired setting as a string or FALSE.
  */
-function hdbt_get_settings(string $setting, string $group = 'site_settings'): string|null {
+function hdbt_get_settings(string $setting, string $group = 'site_settings'): string|NULL {
   return Drupal::config('hdbt_admin_tools.site_settings')
     ?->getOriginal("$group.$setting", FALSE);
 }

--- a/templates/media/media--hel-map.html.twig
+++ b/templates/media/media--hel-map.html.twig
@@ -45,6 +45,7 @@
 {% include '@hdbt/misc/embedded-content-cookie-compliance.twig' with {
   media_url: media_url,
   media_id: media.id,
+  media_iframe_title: iframe_title,
   media_service_url: map_service_url,
   privacy_policy_url: privacy_policy_url,
 } %}

--- a/templates/media/media--remote-video.html.twig
+++ b/templates/media/media--remote-video.html.twig
@@ -36,6 +36,7 @@
 {% include '@hdbt/misc/embedded-content-cookie-compliance.twig' with {
   media_url: media_url,
   media_id: media.id,
+  media_iframe_title: iframe_title,
   media_service_url: video_service_url,
   privacy_policy_url: privacy_policy_url,
 } %}

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -17,7 +17,13 @@
       } %}
 
       {% set external_link_title %}
-         <span class="hds-button__label">{{ 'See content on external site'|t }}</span>
+        {% set button_labelled_by_id = 'button__external-aria-label--' ~ random()|clean_id %}
+         <span class="hds-button__label" aria-labelledby="{{ button_labelled_by_id }}">
+           {{ 'See content on external site'|t }}
+         </span>
+        <span class="is-hidden" id="{{ button_labelled_by_id }}">
+          {{ media_iframe_title }}
+        </span>
       {% endset %}
 
       {{ link(external_link_title, media_url, external_link_attributes) }}

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -15,14 +15,13 @@
           'hds-button--primary',
         ]
       } %}
-
       {% set external_link_title %}
         {% set button_labelled_by_id = 'button__external-aria-label--' ~ random()|clean_id %}
         <span class="is-hidden" id="{{ button_labelled_by_id }}">
-          {{ media_iframe_title }}
+          {{- media_iframe_title -}}
         </span>
         <span class="hds-button__label" aria-labelledby="{{ button_labelled_by_id }}">
-          {{ 'See content on external site'|t }}
+          {{- 'See content on external site'|t -}}
         </span>
       {% endset %}
 

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -18,11 +18,11 @@
 
       {% set external_link_title %}
         {% set button_labelled_by_id = 'button__external-aria-label--' ~ random()|clean_id %}
-         <span class="hds-button__label" aria-labelledby="{{ button_labelled_by_id }}">
-           {{ 'See content on external site'|t }}
-         </span>
         <span class="is-hidden" id="{{ button_labelled_by_id }}">
           {{ media_iframe_title }}
+        </span>
+        <span class="hds-button__label" aria-labelledby="{{ button_labelled_by_id }}">
+          {{ 'See content on external site'|t }}
         </span>
       {% endset %}
 


### PR DESCRIPTION
# [UHF-8465](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8465)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added iframe title field value to variables so that media map templates can use it.
* Passed it for embedded content cookie compliance template and added a separate label for screen readers to read when on the "See content on external site" link.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8465_see_content_on_external_site_link_accessibility`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create a standard page for example that has video and map paragraphs.
* [ ] View the page so that you don't have the cookies accepted.
* [ ] Go to the "See content on external site" links with screen reader and make sure the screen reader reads the iframe title instead of the label that is visible (See content on external site).
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-8465]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ