### PR TITLE
UHF-8595: Added missing TPR fields

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -62,6 +62,50 @@
   {% block main_content %}
     <div class="enriched-content components components--unit">
       {{ content.field_content }}
+
+      {% if content.price_info|render %}
+        {% embed "@hdbt/misc/component.twig" with {
+          component_classes: [ 'component--paragraph-text' ],
+          component_title: content.price_info['#title'],
+        }%}
+          {% block component_content %}
+            {{ content.price_info }}
+          {% endblock component_content %}
+        {% endembed %}
+      {% endif %}
+
+      {% if content.contacts|render %}
+          {% embed "@hdbt/misc/component.twig" with {
+            component_classes: [ 'component--paragraph-text' ],
+            component_title: content.contacts['#title'],
+          }%}
+          {% block component_content %}
+            {{ content.contacts }}
+          {% endblock component_content %}
+        {% endembed %}
+      {% endif %}
+
+      {% if content.links|render %}
+          {% embed "@hdbt/misc/component.twig" with {
+            component_classes: [ 'component--paragraph-text' ],
+            component_title: content.links['#title'],
+          }%}
+          {% block component_content %}
+            {{ content.links }}
+          {% endblock component_content %}
+        {% endembed %}
+      {% endif %}
+
+      {% if content.other_info|render %}
+        {% embed "@hdbt/misc/component.twig" with {
+          component_classes: [ 'component--paragraph-text' ],
+          component_title: content.other_info['#title'],
+        }%}
+          {% block component_content %}
+            {{ content.other_info }}
+          {% endblock component_content %}
+        {% endembed %}
+      {% endif %}
     </div>
   {% endblock main_content %}
 
@@ -75,4 +119,5 @@
       description: content.address,
     } %}
   {% endif %}
+
 </article>


### PR DESCRIPTION
# [UHF-8595](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595)
<!-- What problem does this solve? -->
Some fields from TPR were missing from unit pages.
## What was done
<!-- Describe what was done -->

* Added missing fields to the unit template.

## How to install

* Check the other PR for instructions: https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/147
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/147


[UHF-8595]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ