### PR TITLE
UHF-X: Add better checking for empty title and description fields in components

### DIFF
--- a/templates/misc/component.twig
+++ b/templates/misc/component.twig
@@ -44,6 +44,10 @@ Example usage:
   {% set tag = 'div' %}
 {% endif %}
 
+{# Check if the fields are empty, ignore html comments, non-breaking spaces (&nbsp; and character) and whitespace. #}
+{% set hasTitle = component_title|render|striptags|replace({"&nbsp;":" "," ":" "})|trim %}
+{% set hasDescription = component_description|render|striptags|replace({"&nbsp;":" "," ":" "})|trim %}
+
 <div{{ component_attr.addClass('component', component_classes) }}>
 
   {% if component_koro %}
@@ -51,14 +55,13 @@ Example usage:
   {% endif %}
 
   <div class="component__container">
-
-    {% if component_title|render %}
+    {% if hasTitle %}
       <{{ component_title_level|default('h2') }} class="component__title">
         {{ component_title }}
       </{{ component_title_level|default('h2')}}>
     {% endif %}
 
-    {% if component_description|render %}
+    {% if hasDescription %}
       <div class="component__description user-edited-content">
         {{ component_description}}
       </div>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
There are some pages where editors have entered a single space-character or a non-breaking space to optional fields in components. This causes layout and accessibility problems as our code did not catch these edgecases.

## What was done
<!-- Describe what was done -->

* Common component title and description are now checked for space characters and non-breaking spaces.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_handle_empty_component_fields_better`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that adding space or &nbsp; (on macos use alt+space) does not cause title or description html to appear in components.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
