### PR TITLE
UHF-8759: Add check for news-teaser-generic if the entity is node before checking for the published state

### DIFF
--- a/templates/module/helfi-news-item/news-teaser-generic.twig
+++ b/templates/module/helfi-news-item/news-teaser-generic.twig
@@ -1,8 +1,11 @@
-{%
-  set default_classes = [
-    not node.isPublished() ? 'news-listing__content--unpublished',
-  ]
-%}
+{# External entities don't have published state so check that the printed entity is node #}
+{% if node is not null %}
+  {%
+    set default_classes = [
+      not node.isPublished() ? 'news-listing__content--unpublished',
+    ]
+  %}
+{% endif %}
 
 <div{{ attributes.addClass('news-listing__content', default_classes, class) }}">
   {# Short title or Title #}


### PR DESCRIPTION
# [UHF-8759](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8759)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* News items in news block were shown with unpublished styles even tho they were published. 

## How to install

* Make sure your instance is up and running on latest dev branch. For example KASKO is good for testing this but any will do except for front page.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8759_fix_for_external_entities_appearing_unpublished`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to front page of the instance like [https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus) and there should be a block that lists latest news. They should now have normal styles and not red text etc that they have on testing [https://www.hel.fi/fi/test-kasvatus-ja-koulutus](https://www.hel.fi/fi/test-kasvatus-ja-koulutus).
* [ ] Test also that the functionality that this was originally built for still works. Log in if you already haven't. Go to [https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio) and pick any news from the "Ajankohtaista" block and unpublish it. Now go back to the [https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio) page and it should be shown in the block with red text and unpublished news style. Check also the [https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio/alppilan-lukion-uutiset](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/alppilan-lukio/alppilan-lukion-uutiset) page that the news item is shown as unpublished there as well.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8759]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ