### PR TITLE
UHF-8586: Remove menu local tasks block title

### DIFF
--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -12,10 +12,8 @@
  */
 #}
 {% if primary %}
-  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
   <ul class="local-tasks">{{ primary }}</ul>
 {% endif %}
 {% if secondary %}
-  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
   <ul class="local-tasks">{{ secondary }}</ul>
 {% endif %}


### PR DESCRIPTION
# [UHF-8586](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8586)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The login page starts with a h2-element because the local tasks block has an h2 title. This title is not very useful for the user browsing the page with a screenreader that it is meant for so we should just remove it.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8586_remove_local_tasks_block_title`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to `/user` page when you are not logged in. Inspect the "Log in" and "Reset your password" links and make sure the block around them doesn't have a heading anymore.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8586]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ