### PR TITLE
PLATTA-4940

### DIFF
--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -1,3 +1,7 @@
+{#
+  This twig is called only for certain links
+  see conditions in \Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
+#}
 {% spaceless %}
 
   {% if 'data-selected-icon' in url.options.attributes|keys %}


### PR DESCRIPTION
# [PLATTA-4940](https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4940)

Adding a comment to helfi_link twig that with this change https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/119
The twig template is no longer called for all links, but only for few  - currently the external links + buttons (with icons including) 
This change was done because of performance considerations

[PLATTA-4940]: https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ