### PR TITLE
UHF-8786: Availability summary bug fix

### DIFF
--- a/templates/field/field--tpr-service-channel--availability-summary.html.twig
+++ b/templates/field/field--tpr-service-channel--availability-summary.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+  'label',
+  label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+{% for item in items %}
+  {{ item.content['#text'] }}
+{% endfor %}


### PR DESCRIPTION
# [UHF-8786](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8786)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added field template for availability summary field on service channel to remove wrapping <p>-tag since the content is always just one paragraph.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8786_service_channel_availability_summary_layout_bug`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that on the page[https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/kasvatus-ja-koulutus-yleisavustus]( https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/kasvatus-ja-koulutus-yleisavustus) the "Palvelu saatavilla joka päivä ympäri vuorokauden" text is inline on desktop resolution with the "Vaatii tunnistautumisen" text unlike in the production version [https://www.hel.fi/fi/kasvatus-ja-koulutus/kasvatus-ja-koulutus-yleisavustus](https://www.hel.fi/fi/kasvatus-ja-koulutus/kasvatus-ja-koulutus-yleisavustus).
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8786]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ