### PR TITLE
UHF-8707 other languages bugs

### DIFF
--- a/templates/component/accordion.twig
+++ b/templates/component/accordion.twig
@@ -28,7 +28,7 @@
       {{ content|default('Missing content'|t) }}
 
       <button type="button" class="accordion-item__button accordion-item__button--close" aria-controls="{{ controlled_content_id }}" aria-labelledby="{{ close_button_labelled_by_id }}">
-        <span class="is-hidden" id="{{ close_button_labelled_by_id }}">{{ 'Close element: '|t({}, {'context': 'The helper text for close accordion visibility button'}) }}{{ heading|default('Missing heading'|t) }}</span>
+        <span class="is-hidden" id="{{ close_button_labelled_by_id }}"><span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang })) }}>{{ 'Close element: '|t({}, {'context': 'The helper text for close accordion visibility button'}) }}</span>{{ heading|default('Missing heading'|t) }}</span>
         {{ 'Close'|t({}, {'context': 'The text for close accordion visibility button'}) }}
       </button>
     </div>

--- a/templates/component/accordion.twig
+++ b/templates/component/accordion.twig
@@ -28,8 +28,8 @@
       {{ content|default('Missing content'|t) }}
 
       <button type="button" class="accordion-item__button accordion-item__button--close" aria-controls="{{ controlled_content_id }}" aria-labelledby="{{ close_button_labelled_by_id }}">
-        <span class="is-hidden" id="{{ close_button_labelled_by_id }}"><span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang })) }}>{{ 'Close element: '|t({}, {'context': 'The helper text for close accordion visibility button'}) }}</span>{{ heading|default('Missing heading'|t) }}</span>
-        {{ 'Close'|t({}, {'context': 'The text for close accordion visibility button'}) }}
+        <span class="is-hidden" id="{{ close_button_labelled_by_id }}"><span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Close element: '|t({}, {'context': 'The helper text for close accordion visibility button'}) }}</span>{{ heading|default('Missing heading'|t) }}</span>
+        <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Close'|t({}, {'context': 'The text for close accordion visibility button'}) }}</span>
       </button>
     </div>
   </div>

--- a/templates/misc/component.twig
+++ b/templates/misc/component.twig
@@ -56,7 +56,7 @@ Example usage:
 
   <div class="component__container">
     {% if hasTitle %}
-      <{{ component_title_level|default('h2') }} class="component__title">
+      <{{ component_title_level|default('h2') }} class="component__title" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
         {{ component_title }}
       </{{ component_title_level|default('h2')}}>
     {% endif %}

--- a/templates/misc/component.twig
+++ b/templates/misc/component.twig
@@ -56,7 +56,7 @@ Example usage:
 
   <div class="component__container">
     {% if hasTitle %}
-      <{{ component_title_level|default('h2') }} class="component__title" {{ use_component_title_lang_fallback ? create_attribute(({ 'lang': lang_attributes.fallback_lang })) }}>
+      <{{ component_title_level|default('h2') }} class="component__title" {{ use_component_title_lang_fallback ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
         {{ component_title }}
       </{{ component_title_level|default('h2')}}>
     {% endif %}

--- a/templates/misc/component.twig
+++ b/templates/misc/component.twig
@@ -56,7 +56,7 @@ Example usage:
 
   <div class="component__container">
     {% if hasTitle %}
-      <{{ component_title_level|default('h2') }} class="component__title" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+      <{{ component_title_level|default('h2') }} class="component__title" {{ use_component_title_lang_fallback ? create_attribute(({ 'lang': lang_attributes.fallback_lang })) }}>
         {{ component_title }}
       </{{ component_title_level|default('h2')}}>
     {% endif %}


### PR DESCRIPTION
# [UHF-8707](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8707)
<!-- What problem does this solve? -->
* Part of accordion close button's screen reader text didn't have fallback lang attribute.
* Latest news component title doesn't have lang attribute.

## What was done
<!-- Describe what was done -->

* Added missing lang fallback attributes.

## How to install

* Make sure your etusivu instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8707_other-languages-bugs`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Find or add accordion and latest news component to any page that is on other language (not en, fi or sv).
* [x] Check that the "Close element: " text for screen readers in the accordion close button is now wrapped with `<span lang="en">`.
* [x] Check that the "Latest news" H2 in Latest news -component is wrapped with `lang="en"`. 
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/420)


[UHF-8707]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ