### PR TITLE
UHF-7650: Fix helsinki info button

### DIFF
--- a/dist/js/disable-genesys-button.min.js
+++ b/dist/js/disable-genesys-button.min.js
@@ -1,1 +1,1 @@
-!function(e,Drupal,drupalSettings){Drupal.behaviors.disable_genesys_button={attach(t,n){"undefined"==typeof _genesys&&e("#openChat").replaceWith(`<div>${Drupal.t("Chat is not in use.")}</div>`)}}}(jQuery,Drupal,drupalSettings);
+!function(e,Drupal,drupalSettings){Drupal.behaviors.disable_genesys_button={attach(s,t){"undefined"==typeof _genesys&&e("#openChat").replaceWith(`<div id='genesys-disabled-message'>${Drupal.t("Chat is not in use.")}</div>`)}}}(jQuery,Drupal,drupalSettings);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7429,9 +7429,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001521",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
+      "version": "1.0.30001522",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
+      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -27513,9 +27513,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001521",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ=="
+      "version": "1.0.30001522",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
+      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/src/js/disable-genesys-button.js
+++ b/src/js/disable-genesys-button.js
@@ -5,7 +5,7 @@
     attach(context, settings) {
       // Don't show the button if the chat element does not exist.
       if (typeof _genesys === 'undefined') {
-        $('#openChat').replaceWith(`<div>${Drupal.t('Chat is not in use.')}</div>`);
+        $('#openChat').replaceWith(`<div id='genesys-disabled-message'>${Drupal.t('Chat is not in use.')}</div>`);
       }
     },
   };


### PR DESCRIPTION
# [UHF-7650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7650)
Make button on helsinki info pages usable again.

## What was done
* Added ID to genesys-disabled message to make it replaceable from the neuvonta chat script. Neuvonta script loads genesys from external source and seems that global `_genesys` object is never available when the `disable-genesys-button` script executes.
* Updated `caniuse-lite`

## How to install & test:

* Check instructions here: 


[UHF-7650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ