### PR TITLE
UHF-8838: Template for services bulletin listing

### DIFF
--- a/src/scss/06_components/pages/_unit.scss
+++ b/src/scss/06_components/pages/_unit.scss
@@ -119,7 +119,7 @@
       margin-top: $spacing-triple;
     }
 
-    .service {
+    .service--teaser {
       width: 100%;
 
       @include breakpoint($breakpoint-l) {

--- a/templates/module/helfi_tpr/tpr-service.html.twig
+++ b/templates/module/helfi_tpr/tpr-service.html.twig
@@ -7,7 +7,7 @@
  */
 #}
 
-{% if view_mode != 'teaser' %}
+{% if view_mode == 'full' %}
 
   <article class="service service--full">
 
@@ -56,4 +56,22 @@
     </a>
   </div>
 
+
+{% elseif view_mode == 'listing' %}
+
+  {%
+    set service_classes = [
+      'service',
+      'service--listing',
+      not content_entity_published ? 'service--listing--unpublished',
+    ]
+  %}
+
+  {% set wrapper_attributes = create_attribute() %}
+
+  <li{{ wrapper_attributes.addClass(service_classes) }}>
+    <a href="{{ url('entity.tpr_service.canonical', { 'tpr_service': entity.id() }) }}">
+      {{ entity.label }}
+    </a>
+  </li>
 {% endif %}

--- a/templates/module/helfi_tpr/tpr-unit-lower-content.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit-lower-content.html.twig
@@ -20,7 +20,7 @@
   %}
     {% block component_content %}
       <div class="unit__services">
-        {{ drupal_view('unit_services', 'unit_services') }}
+        {{ drupal_view('unit_services', 'unit_services_listing') }}
       </div>
     {% endblock component_content %}
   {% endembed %}

--- a/templates/views/views-view--unit-services.html.twig
+++ b/templates/views/views-view--unit-services.html.twig
@@ -51,9 +51,21 @@
     {% endif %}
   </div>
 
+ {% if display_id != 'unit_services_listing' %}
+
   <div class="unit__services__list">
     {{ rows }}
   </div>
+
+ {% elseif display_id == 'unit_services_listing'  %}
+
+  <div class="unit__services__list">
+    <ul>
+      {{ rows }}
+    </ul>
+  </div>
+
+ {% endif %}
 
   {{ empty }}
   {{ pager }}


### PR DESCRIPTION
# [UHF-8838](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8838)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Use instance of https://github.com/City-of-Helsinki/drupal-helfi-sote
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8838_Service_listing_seo`
* Update the drupal-helfi-platform-config
  * `composer require drupal/helfi_platform_config:dev-UHF-8838_Service_listing_seo`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/terveysasemat/haagan-terveysasema and check that Services list is now bulletin list instead of cards
* [ ] Close the other PR's if valid
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review


## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/576


[UHF-8838]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ