### PR TITLE
UHF-X: Hide empty title from service channel TPR content

### DIFF
--- a/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -9,13 +9,15 @@
   {% set show_mail = true %}
 {% endif %}
 
-{%  set service_channel_heading_level = service_channel_heading_level|default('h4') %}
-
 {% set service_channel_eservice_links_new_tab = service_channel_eservice_links_new_tab|default(0) %}
 <div class="service-channel__content">
-  <{{ service_channel_heading_level }} class="service-channel__title">
-    {{ content.name }}
-  </{{ service_channel_heading_level }}>
+
+  {% if content.name|render %}
+    {% set service_channel_heading_level = service_channel_heading_level|default('h4') %}
+    <{{ service_channel_heading_level }} class="service-channel__title">
+      {{ content.name }}
+    </{{ service_channel_heading_level }}>
+  {% endif %}
 
   {% if content.availability_summary|render %}
     <div class="service-channel__availabilities">{{ content.availability_summary }}</div>


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
We have empty headings in a minor amount of content


## What was done
<!-- Describe what was done -->

* A check was added to avoid creating empty headings

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh` on kymp instance
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_service_channel_empty_title`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that empty content no longer appears on [kymp page](https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pysakointi/ajoneuvojen-siirrot)
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review