### PR TITLE
UHF-8938: Caption field for TPR-units

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1297,6 +1297,16 @@ function hdbt_preprocess_tpr_unit(&$variables): void {
 
   // Add cookie compliance JS to unit pages since they have maps.
   $variables['#attached']['library'][] = 'hdbt/embedded-content-cookie-compliance';
+
+  // Handle TPR unit picture caption preprocessing.
+  if ($entity->hasField('picture_url_override')) {
+    _hdbt_preprocess_image_caption(
+      $variables,
+      'entity',
+      'picture_url_override',
+      'unit_picture_caption'
+    );
+  }
 }
 
 /**

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -45,10 +45,18 @@
     {% set main_image = content.picture_url %}
   {% endif %}
 
+  {# Main image caption #}
+  {% if content.picture_url_override_caption|render %}
+    {% set main_image_caption = content.picture_url_override_caption %}
+  {% elseif content.picture_url_override_caption|render %}
+    {% set main_image_caption = '' %}
+  {% endif %}
+
   {% if main_image %}
     {% include '@hdbt/misc/image-with-caption.twig' with {
       figure_class: 'main-image',
-      image: main_image
+      image: main_image,
+      image_caption: main_image_caption
     } %}
   {% endif %}
   {# End of Main image #}

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -46,9 +46,9 @@
   {% endif %}
 
   {# Main image caption #}
-  {% if content.picture_url_override_caption|render %}
-    {% set main_image_caption = content.picture_url_override_caption %}
-  {% elseif content.picture_url_override_caption|render %}
+  {% if content.unit_picture_caption|render %}
+    {% set main_image_caption = content.unit_picture_caption %}
+  {% else %}
     {% set main_image_caption = '' %}
   {% endif %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -46,8 +46,8 @@
   {% endif %}
 
   {# Main image caption #}
-  {% if content.unit_picture_caption|render %}
-    {% set main_image_caption = content.unit_picture_caption %}
+  {% if unit_picture_caption|render %}
+    {% set main_image_caption = unit_picture_caption %}
   {% else %}
     {% set main_image_caption = '' %}
   {% endif %}


### PR DESCRIPTION
# [UHF-8938](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8938)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add field unit picture caption and make it function the same way as other caption fields.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
  * `make drush-cim drush-cr`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8938`
* Update the helfi_platform_config
  * `composer require drupal/helfi_platform_config:dev-UHF-8938`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to edit any TPR-unit but preferably one with a picture from TPR. For example `https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/rakennusvalvonnan-arkisto` is good.
* [x] Make sure there is now new field called "Caption" on the TPR-unit.
* [x] Write something for the field and make sure that the text is displayed under the unit picture after saving.
* [x] Now go back to edit the unit and add an override picture for the unit and make sure to add a picture there that has the photographer field filled.
* [x] Save and check that there is now the caption and the photographer info displayed under the picture.
* [x] Now go back to edit the unit again and remove the caption and save.
* [x] Now it should only display photographer information under the picture. 
* [x] Once again go back to edit the unit and remove the photo and save.
* [x] Now there should be just the unit picture with no caption at all.
* [x] Now repeat the same steps as above but for some other language version of the unit page and make sure that the translations don't leak to other languages.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/606


[UHF-8938]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ