### PR TITLE
UHF-9178: open the link in same window

### DIFF
--- a/templates/paragraphs/paragraph--hearings.html.twig
+++ b/templates/paragraphs/paragraph--hearings.html.twig
@@ -27,7 +27,6 @@
           url: 'https://kerrokantasi.hel.fi/hearings/list?lang=' ~ current_langcode,
           class: 'hearings__link',
           is_external: true,
-          open_in_a_new_window: true,
         } %}
       {% else %}
         <section class="hearings__results">
@@ -39,7 +38,6 @@
           url: 'https://kerrokantasi.hel.fi/hearings/list?lang=' ~ current_langcode,
           class: 'hearings__link',
           is_external: true,
-          open_in_a_new_window: true,
         } %}
       {% endif %}
     {% endblock component_content %}


### PR DESCRIPTION
# [UHF-9178](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9178)
open the link in same window

## What was done
removed target=blank

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
- Go to any landing page and add a hearings paragraph to it
- Go see the paragraph.

The "see all hearings(katso kaikki kuulemiset)" link should open in same tab instead of opening a new tab 

* [x] Check that this feature works
* [x] Check that code follows our standards



[UHF-9178]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ