### PR TITLE
UHF-9068: Fix visibility of image without caption

### DIFF
--- a/templates/module/helfi_tpr/tpr-service.html.twig
+++ b/templates/module/helfi_tpr/tpr-service.html.twig
@@ -27,7 +27,7 @@
       </div>
     {% endif %}
 
-    {% if content.field_content|render|striptags|trim is not empty %}
+    {% if content.field_content|render is not empty %}
       <div class="enriched-content components components--upper components--service">
         {{ content.field_content }}
       </div>


### PR DESCRIPTION
# [UHF-9068](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9068)
<!-- What problem does this solve? -->
Image paragraph on TPR Service page was not displayed if image didn't have caption text.
 
## What was done
<!-- Describe what was done -->

* Updated rendering filters for conditional statement for Upper Content region.

## How to install

* Recommendation of using https://github.com/City-of-Helsinki/drupal-helfi-sote
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9068_Image_not_visible`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Image with and without caption is visible on page https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset/palvelukeskuksen-sauna
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->



[UHF-9068]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ