### PR TITLE
UHF-7841: Add Video prefix for iframe title

### DIFF
--- a/templates/media/media--remote-video.html.twig
+++ b/templates/media/media--remote-video.html.twig
@@ -52,7 +52,7 @@
           'src': media_attributes.src,
           'height': media_attributes.height,
           'width': media_attributes.width,
-          'title': iframe_title,
+          'title': 'Video: ' ~ iframe_title,
           'type': 'video',
         }
       }


### PR DESCRIPTION
# [UHF-7841](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7841)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added "Video: " prefix for remote videos iframe title for accessibility improvements

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7841_Video_accessibility_updates`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add new remote video paragraph and check that iframe title has "Video: " prefix
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
