### PR TITLE
UHF-9298: Fixed other info accordion bug in tpr units

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -96,65 +96,63 @@
             component_content_class: 'accordion',
           }
         %}
-        {% block component_content %}
+          {% block component_content %}
+            {% if has_prices %}
+              {% set accordion_content %}
 
-          {% if has_prices %}
-            {% set accordion_content %}
+                {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
+                  {% block component_content %}
+                    {{ content.price_info }}
+                  {% endblock component_content %}
+                {% endembed %}
 
-              {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
-                {% block component_content %}
-                  {{ content.price_info }}
-                {% endblock component_content %}
-              {% endembed %}
+              {% endset %}
 
-            {% endset %}
+              {% include '@hdbt/component/accordion.twig' ignore missing with {
+                heading_level: 'h2',
+                heading: 'Charges'|t({}, {'context': 'TPR Unit tpr data accordion heading'}),
+                content: accordion_content,
+              } %}
+            {% endif %}
 
-            {% include '@hdbt/component/accordion.twig' ignore missing with {
-              heading_level: 'h2',
-              heading: 'Charges'|t({}, {'context': 'TPR Unit tpr data accordion heading'}),
-              content: accordion_content,
-            } %}
-          {% endif %}
+            {% if has_contacts %}
+              {% set contacts_accordion_content %}
 
-          {% if has_contacts %}
-            {% set contacts_accordion_content %}
+                {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
+                  {% block component_content %}
+                    {{ content.contacts }}
+                  {% endblock component_content %}
+                {% endembed %}
 
-              {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
-                {% block component_content %}
-                  {{ content.contacts }}
-                {% endblock component_content %}
-              {% endembed %}
+              {% endset %}
 
-            {% endset %}
-
-            {% include '@hdbt/component/accordion.twig' ignore missing with {
-              heading_level: 'h2',
-              heading: 'Other contact information'|t({}, {'context': 'TPR Unit tpr data accordion heading'}) ,
-              content: contacts_accordion_content,
-            } %}
-          {% endif %}
+              {% include '@hdbt/component/accordion.twig' ignore missing with {
+                heading_level: 'h2',
+                heading: 'Other contact information'|t({}, {'context': 'TPR Unit tpr data accordion heading'}) ,
+                content: contacts_accordion_content,
+              } %}
+            {% endif %}
  
-          {% if has_other_info %}
-            {% set other_info_accordion_content %}
+            {% if has_other_info %}
+              {% set other_info_accordion_content %}
 
-              {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
-                {% block component_content %}
-                  {{ content.highlights }}
-                  {{ content.topical }}
-                  {{ content.other_info }}
-                  {{ content.links }}
-                {% endblock component_content %}
-              {% endembed %}
+                {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
+                  {% block component_content %}
+                    {{ content.highlights }}
+                    {{ content.topical }}
+                    {{ content.other_info }}
+                    {{ content.links }}
+                  {% endblock component_content %}
+                {% endembed %}
 
-            {% endset %}
-          {% endif %}
+              {% endset %}
 
-          {% include '@hdbt/component/accordion.twig' ignore missing with {
-            heading_level: 'h2',
-            heading: 'Further information'|t({}, {'context': 'TPR Unit tpr data accordion heading'}),
-            content: other_info_accordion_content,
-          } %}
-
+              {% include '@hdbt/component/accordion.twig' ignore missing with {
+                heading_level: 'h2',
+                heading: 'Further information'|t({}, {'context': 'TPR Unit tpr data accordion heading'}),
+                content: other_info_accordion_content,
+              } %}
+            {% endif %}
           {% endblock component_content %}
         {% endembed %}
       {% endif %}


### PR DESCRIPTION
# [UHF-9298](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9298)
<!-- What problem does this solve? -->

Other info accordion is displayed on TPR units even if it doesn't have any content.
Example: https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/sairaalat-ja-poliklinikat/laakson-sairaala.

## What was done
<!-- Describe what was done -->

* Moved the accordion rendering to be inside the if statement.
* Fixed indenting.

## How to install

* Make sure your **SOTE** instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9298_other-info-accordion-bug`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/sairaalat-ja-poliklinikat/laakson-sairaala and check that the "Lisätiedot" accordion has disappeared.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-9298]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ