### PR TITLE
UHF-9159: Added subgroup accordion

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1335,12 +1335,12 @@ function hdbt_preprocess_tpr_unit(&$variables): void {
   }
 
   // Check if the unit is a daycare unit.
-  $variables['is_daycare_unit'] = false;
+  $variables['is_daycare_unit'] = FALSE;
   if ($entity->hasField('field_unit_type')) {
     $types = $entity->get('field_unit_type')->referencedEntities();
     foreach ($types as $type) {
       if ($type->id() == 1) {
-        $variables['is_daycare_unit'] = true;
+        $variables['is_daycare_unit'] = TRUE;
       }
     }
   }

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1333,6 +1333,17 @@ function hdbt_preprocess_tpr_unit(&$variables): void {
       'unit_picture_caption'
     );
   }
+
+  // Check if the unit is a daycare unit.
+  $variables['is_daycare_unit'] = false;
+  if ($entity->hasField('field_unit_type')) {
+    $types = $entity->get('field_unit_type')->referencedEntities();
+    foreach ($types as $type) {
+      if ($type->id() == 1) {
+        $variables['is_daycare_unit'] = true;
+      }
+    }
+  }
 }
 
 /**

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -9,6 +9,7 @@
 {% set has_prices = content.price_info|render ? true : false %}
 {% set has_contacts = content.contacts|render ? true : false %}
 {% set has_ontologyword_details = content.field_ontologyword_details|render ? true : false %}
+{% set has_subgroup = content.subgroup|render ? true : false %}
 {% set has_other_info = content.highlights|render or content.topical|render or content.other_info|render or content.links|render ?: false %}
 
 {% set supports_swedish %}
@@ -86,7 +87,7 @@
 
       {{ content.field_content }}
 
-      {% if has_prices or has_contacts or has_other_info %}
+      {% if has_prices or has_contacts or has_other_info or has_subgroup %}
         {% embed "@hdbt/misc/component.twig" with
           {
             component_classes: [
@@ -134,16 +135,29 @@
               } %}
             {% endif %}
 
+            {% if has_subgroup %}
+              {% set subgroup_accordion_content %}
+
+                {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
+                  {% block component_content %}
+                    {{ content.subgroup }}
+                  {% endblock component_content %}
+                {% endembed %}
+
+              {% endset %}
+              {% include '@hdbt/component/accordion.twig' ignore missing with {
+                heading_level: 'h2',
+                heading: 'Contact details of daycare centre groups'|t({}, {'context': 'TPR Unit tpr data accordion heading'}) ,
+                content: subgroup_accordion_content,
+              } %}
+            {% endif %}
+
             {% if has_ontologyword_details %}
               {% set ontologyword_details_accordion_content %}
 
                 {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
                   {% block component_content %}
                     {{ content.field_ontologyword_details }}
-                  {% endblock component_content %}
-                {% endembed %}
-
-              {% endset %}
 
               {% include '@hdbt/component/accordion.twig' ignore missing with {
                 heading_level: 'h2',
@@ -152,7 +166,7 @@
               } %}
 
             {% endif %}
-
+ 
             {% if has_other_info %}
               {% set other_info_accordion_content %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -87,7 +87,7 @@
 
       {{ content.field_content }}
 
-      {% if has_prices or has_contacts or has_other_info or has_subgroup %}
+      {% if has_prices or has_contacts or has_other_info or has_subgroup or has_ontologyword_details %}
         {% embed "@hdbt/misc/component.twig" with
           {
             component_classes: [
@@ -164,9 +164,8 @@
                 heading: 'Language program and weighted curriculum education'|t({}, {'context': 'TPR Ontologyword details schools'}),
                 content: ontologyword_details_accordion_content,
               } %}
-
             {% endif %}
- 
+
             {% if has_other_info %}
               {% set other_info_accordion_content %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -158,6 +158,9 @@
                 {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
                   {% block component_content %}
                     {{ content.field_ontologyword_details }}
+                  {% endblock component_content %}
+                {% endembed %}
+              {% endset %}
 
               {% include '@hdbt/component/accordion.twig' ignore missing with {
                 heading_level: 'h2',

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -135,7 +135,7 @@
               } %}
             {% endif %}
 
-            {% if has_subgroup %}
+            {% if is_daycare_unit and has_subgroup %}
               {% set subgroup_accordion_content %}
 
                 {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -834,3 +834,7 @@ msgstr "Tyhjennä valinnat"
 msgctxt "Job search no results message"
 msgid "Jobs meeting search criteria was not found. Try different search criteria."
 msgstr "Hakuehtoja vastaavia työpaikkoja ei löytynyt. Kokeile muita hakuehtoja."
+
+msgctxt "TPR Unit tpr data accordion heading"
+msgid "Contact details of daycare centre groups"
+msgstr "Päiväkotiryhmien yhteystiedot"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -827,3 +827,7 @@ msgstr "Töm urvalet"
 msgctxt "Job search no results message"
 msgid "Jobs meeting search criteria was not found. Try different search criteria."
 msgstr "Lediga jobb som uppfyller kriterierna finns inte. Prova andra kriterierna för sök."
+
+msgctxt "TPR Unit tpr data accordion heading"
+msgid "Contact details of daycare centre groups"
+msgstr "Barngruppernas kontaktuppgifter"


### PR DESCRIPTION
# [UHF-9159](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Display subgroups in an accordion

## How to install

* Follow the instuctions in https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/161.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] The subgroup data should be nicely displayed in an accordion.
* [ ] Check that the code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/161


[UHF-9159]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ