### PR TITLE
UHF-X: Improve check for tools__container content

### DIFF
--- a/templates/layout/region--tools.html.twig
+++ b/templates/layout/region--tools.html.twig
@@ -12,7 +12,7 @@
  * @see template_preprocess_region()
  */
 #}
-{% if content %}
+{% if content|render %}
   <div{{ attributes.addClass('tools__container') }}>
     {{ content }}
   </div>


### PR DESCRIPTION
# UHF-X empty tools__container appears to non-admins
<!-- What problem does this solve? -->
On many pages (6k+) we have empty `tools__container` element from drupal as the check did not work in all cases.

## What was done
<!-- Describe what was done -->

* twig if was improved by adding `|render`

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_tools__container`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that `tools__container` no longer appears on fi/kaupunkiymparisto-ja-liikenne/pyoraily/pyorateiden-talvihoito when not logged in
* [ ] Check that `tools__container` still works when logged in as admin
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

