### PR TITLE
UHF-9309 link to static copy of the site

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1499,16 +1499,19 @@ function hdbt_preprocess_maintenance_page(&$variables): void {
     case 'fi':
       $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/fi';
       $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute';
+      $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/fi.html';
       break;
 
     case 'sv':
       $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/sv';
       $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback';
+      $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/sv.html';
       break;
 
     default:
       $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/en';
       $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/en/administration/participate/feedback';
+      $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/en.html';
       break;
   }
 }

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -37,6 +37,13 @@
         {% endset %}
         {{ link(feedback_link_title, maintenance_page_feedback_link, link_attributes) }}
 
+        <br>
+
+        {% set copy_link_title %}
+          {{ 'If the problem persist, go to the copy of the pages.'|t({}, {'context': 'Copy of site link for error pages'}) }}
+        {% endset %}
+        {{ link(copy_link_title, maintenance_page_copy_link, link_attributes) }}
+
       </main>
     </div>
     <div class="maintenance-page__illustration-container">

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -13,7 +13,7 @@
   {% block container_content %}
     <div class="maintenance-page__text-container">
       <header role="banner">
-        <h1 class="maintenance-page__title">{{ 'The site is currently under maintenance'|t }}</h1>
+        <h1 class="maintenance-page__title" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'The site is currently under maintenance'|t }}</h1>
       </header>
       <main role="main">
         <p class="maintenance-page__description">
@@ -28,6 +28,13 @@
             'maintenance-page__link',
           ],
         } %}
+        {% if alternative_language %}
+          {% set link_attributes = link_attributes|merge({
+              'dir': lang_attributes.fallback_dir,
+              'lang': lang_attributes.fallback_lang
+            })
+          %}
+        {% endif %}
         {{ link(link_title, maintenance_page_home_link, link_attributes) }}
 
         <br>

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -838,3 +838,7 @@ msgstr "Hakuehtoja vastaavia työpaikkoja ei löytynyt. Kokeile muita hakuehtoja
 msgctxt "TPR Unit tpr data accordion heading"
 msgid "Contact details of daycare centre groups"
 msgstr "Päiväkotiryhmien yhteystiedot"
+
+msgctxt "Copy of site link for error pages"
+msgid "If the problem persist, go to the copy of the pages."
+msgstr "Jos ongelma jatkuu siirry sivun kopioon."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -831,3 +831,7 @@ msgstr "Lediga jobb som uppfyller kriterierna finns inte. Prova andra kriteriern
 msgctxt "TPR Unit tpr data accordion heading"
 msgid "Contact details of daycare centre groups"
 msgstr "Barngruppernas kontaktuppgifter"
+
+msgctxt "Copy of site link for error pages"
+msgid "If the problem persist, go to the copy of the pages."
+msgstr "Om problemet kvarstår, gå till den kopian av sidorna."


### PR DESCRIPTION
# [UHF-9309](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9309)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added a link leading to the copy of the site to the maintenance page.

## How to install

* Make sure your **etusivu** instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-locale-update drush-cr`
* Run `drush state:set system.maintenance_mode 1 --input-format=integer` to put the site to the maintenance mode.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Open https://helfi-etusivu.docker.so/en and check that there is now a link to the static copy of the site.
* [x] Open https://helfi-etusivu.docker.so/fi and https://helfi-etusivu.docker.so/sv to check that the translations work.
* [x] Check the maintenance page in any of the alternative language, for example: https://helfi-etusivu.docker.so/uk. The links and the H1 title should now have correct fallback `lang` and `dir` attributes.
* [ ] Check that code follows our standards.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [x] This PR has been visually reviewed by a designer (Nina Hiukkanen)


[UHF-9309]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ