### PR TITLE
UHF-9249 moving tpr unit accordions and use description override

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -65,9 +65,13 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if content.description|render and hide_description == false %}
+  {% if content.description|render or content.description_override and hide_description == false %}
     <div class="long-desc user-edited-content">
-      {{ content.description }}
+      {% if content.description_override|render %}
+        {{ content.description_override }}
+      {% else %}
+        {{ content.description }}
+      {% endif %}
     </div>
   {% endif %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -85,8 +85,6 @@
         {% endblock component_content %}
       {% endembed %}
 
-      {{ content.field_content }}
-
       {% if has_prices or has_contacts or has_other_info or has_subgroup or has_ontologyword_details %}
         {% embed "@hdbt/misc/component.twig" with
           {
@@ -192,6 +190,9 @@
           {% endblock component_content %}
         {% endembed %}
       {% endif %}
+
+      {{ content.field_content }}
+
     </div>
   {% endblock main_content %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -65,7 +65,7 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if content.description|render or content.description_override and hide_description == false %}
+  {% if (content.description|render or content.description_override) and hide_description == false %}
     <div class="long-desc user-edited-content">
       {% if content.description_override|render %}
         {{ content.description_override }}


### PR DESCRIPTION
# [UHF-9249](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved the TPR data accordions to be before the upper content region.
* Show description override field instead of description if filled.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-9249]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ