### PR TITLE
UHF-X Fix for helfi link icons

### DIFF
--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -1,6 +1,6 @@
 {#
-  This twig is called only for certain links
-  see conditions in \Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
+This twig is called only for certain links
+see conditions in \Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
 #}
 {% apply spaceless %}
 
@@ -19,35 +19,35 @@
   {% endif %}
 
   {% if 'data-selected-icon' in url.options.attributes|keys %}
-      {% if render_old_link %}
-        {% set selected_icon -%}{% include '@hdbt/misc/icon.twig' ignore missing with {icon: url.options.attributes['data-selected-icon']} only %}{%- endset %}
-      {% endif %}
+    {% if render_old_link %}
+      {% set selected_icon -%}{% include '@hdbt/misc/icon.twig' ignore missing with {icon: url.options.attributes['data-selected-icon']} only %}{%- endset %}
+    {% endif %}
   {% endif %}
 
   {% if 'data-is-external' in attributes|keys %}
-    {% set attribute_icon %}
+    {%- set attribute_icon -%}
       {%- if render_old_link -%}
         <span class="link__type link__type--external"></span>
       {%- endif -%}
       <span class="visually-hidden" lang="{{ descriptive_lang }}" dir="{{ descriptive_lang_dir }}">({{ 'Link leads to external service'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link leads to an external service.'}) }})</span>
-    {% endset %}
+    {%- endset -%}
   {% endif %}
 
   {% if 'data-protocol' in attributes|keys and attributes['data-protocol'] != 'false'%}
     {% if attributes['data-protocol'] == 'tel' %}
-      {% set attribute_icon %}
-        {% if render_old_link %}
+      {%- set attribute_icon -%}
+        {%- if render_old_link -%}
           <span class="link__type link__type--tel"></span>
-        {% endif %}
+        {%- endif -%}
         <span class="visually-hidden" lang="{{ descriptive_lang }}" dir="{{ descriptive_lang_dir }}">({{ 'Link starts a phone call'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link starts a phone call.'}) }})</span>
-      {% endset %}
+      {%- endset -%}
     {% elseif attributes['data-protocol'] == 'mailto' %}
-      {% set attribute_icon %}
-        {% if render_old_link %}
+      {%- set attribute_icon -%}
+        {%- if render_old_link -%}
           <span class="link__type link__type--mailto"></span>
-        {% endif %}
+        {%- endif -%}
         <span class="visually-hidden" lang="{{ descriptive_lang }}" dir="{{ descriptive_lang_dir }}">({{ 'Link opens default mail program'|t({}, {'context': 'Explanation for screen-reader software that the icon visible next to this link means that the link opens default mail program.'}) }})</span>
-      {% endset %}
+      {%- endset -%}
     {% endif %}
   {% endif %}
 

--- a/templates/module/helfi_api_base/helfi-link.html.twig
+++ b/templates/module/helfi_api_base/helfi-link.html.twig
@@ -1,6 +1,6 @@
 {#
-This twig is called only for certain links
-see conditions in \Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
+  This twig is called only for certain links
+  see conditions in \Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
 #}
 {% apply spaceless %}
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Fixed empty space issue on helfi-link template with email/phone icons.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_fix_for_helfi_link_icons`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the empty spaces from links on the sidebar in this page has been fixed https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/kouluun-ilmoittautuminen-ja-hakeminen/painotettu-opetus-ja-perusopetusta-eri-kielilla/englanninkielinen-opetus
   * Check the test instance for reference https://www.hel.fi/fi/test-kasvatus-ja-koulutus/perusopetus/kouluun-ilmoittautuminen-ja-hakeminen/painotettu-opetus-ja-perusopetusta-eri-kielilla/englanninkielinen-opetus
   <img width="372" alt="image" src="https://github.com/City-of-Helsinki/drupal-hdbt/assets/1712902/6b14c2cc-5903-4100-a0f5-1c3d7c08d225">
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

