### PR TITLE
UHF-9249: Use the new description override field

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -65,12 +65,12 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if (content.description|render or content.description_override|render) and hide_description == false %}
+  {% if (content.description|render or content.enrich_description|render) and hide_description == false %}
     <div class="long-desc user-edited-content">
-      {% if content.description_override|render %}
-        {{ content.description_override }}
-      {% else %}
+      {% if content.description|render %}
         {{ content.description }}
+      {% else %}
+        {{ content.enrich_description }}
       {% endif %}
     </div>
   {% endif %}

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -65,9 +65,13 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if content.description|render and hide_description == false %}
+  {% if (content.description|render or content.description_override) and hide_description == false %}
     <div class="long-desc user-edited-content">
-      {{ content.description }}
+      {% if content.description_override|render %}
+        {{ content.description_override }}
+      {% else %}
+        {{ content.description }}
+      {% endif %}
     </div>
   {% endif %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -11,7 +11,8 @@
 {% set has_ontologyword_details = content.field_ontologyword_details|render ? true : false %}
 {% set has_subgroup = content.subgroup|render ? true : false %}
 {% set has_other_info = content.highlights|render or content.topical|render or content.other_info|render or content.links|render ?: false %}
-{% set show_description = (content.description.0['#text'] or content.enrich_description.0['#text']) and hide_description == false ?: false %}
+{% set description = content.description.0['#text'] ? content.description : content.enrich_description %}
+{% set show_description = description.0['#text'] and hide_description == false ?: false %}
 
 {% set supports_swedish %}
   {% if 'sv' in provided_languages %}
@@ -68,11 +69,7 @@
 
   {% if show_description %}
     <div class="long-desc user-edited-content">
-      {% if content.description.0['#text'] %}
-        {{ content.description }}
-      {% else %}
-        {{ content.enrich_description }}
-      {% endif %}
+      {{ description }}
     </div>
   {% endif %}
 

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -65,7 +65,7 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if (content.description|render or content.description_override) and hide_description == false %}
+  {% if (content.description|render or content.description_override|render) and hide_description == false %}
     <div class="long-desc user-edited-content">
       {% if content.description_override|render %}
         {{ content.description_override }}

--- a/templates/module/helfi_tpr/tpr-unit.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit.html.twig
@@ -11,6 +11,7 @@
 {% set has_ontologyword_details = content.field_ontologyword_details|render ? true : false %}
 {% set has_subgroup = content.subgroup|render ? true : false %}
 {% set has_other_info = content.highlights|render or content.topical|render or content.other_info|render or content.links|render ?: false %}
+{% set show_description = (content.description.0['#text'] or content.enrich_description.0['#text']) and hide_description == false ?: false %}
 
 {% set supports_swedish %}
   {% if 'sv' in provided_languages %}
@@ -65,9 +66,9 @@
   {% endif %}
   {# End of Main image #}
 
-  {% if (content.description|render or content.enrich_description|render) and hide_description == false %}
+  {% if show_description %}
     <div class="long-desc user-edited-content">
-      {% if content.description|render %}
+      {% if content.description.0['#text'] %}
         {{ content.description }}
       {% else %}
         {{ content.enrich_description }}


### PR DESCRIPTION
# [UHF-9249](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Use the description override if the TPR data for description is empty.

## How to install and test

* Check the instructions in https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/653

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/653


[UHF-9249]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ