### PR TITLE
UHF-X: Fix nested p-tags in tpr-service-teaser description

### DIFF
--- a/templates/module/helfi_tpr/tpr-service--teaser-search-result.html.twig
+++ b/templates/module/helfi_tpr/tpr-service--teaser-search-result.html.twig
@@ -10,6 +10,7 @@
   card_title: entity.label,
   card_url: service_url,
   card_description: content.description,
+  card_description_html: true,
   card_tags: content.errand_services[0]['#items'],
 } %}
 {% endembed %}


### PR DESCRIPTION
# UHF-X: Fix nested p-tags in tpr-service-teaser description
<!-- What problem does this solve? -->
Advisory services listing has invalid `p > p` structure as the card component is called as if the description would not have html formatting. 

This causes the browser to create empty p-tags before and after the description content.
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/49ef0e1a-c0ab-4ab0-bd88-6e0822fa3f6d)


## What was done
<!-- Describe what was done -->

* tpr-service--teaser-search-result.html.twig was modified to tell the card template that the card_description format is indeed html.

## How to install

* Make sure your *Strategia* instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_advisory_services_teaser_html`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that [Neuvontapalvelut](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/ota-yhteytta-helsingin-kaupunkiin/neuvontapalvelut) no longer produces faulty `p`-elements.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
