### PR TITLE
UHF-9230: Remove unnecessary "-" from after school activity card

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit--minimal.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit--minimal.html.twig
@@ -24,7 +24,7 @@
   {% set card_metas = card_metas|merge([{
       icon: 'clock',
       label: 'Opening hours'|t({}, {'context': 'TPR unit result card'}),
-      content: content.opening_hours|render|striptags,
+      content: content.opening_hours|render|striptags|replace({'\n-': ''}),
     }]) %}
 {% endif %}
 

--- a/templates/module/helfi_tpr/tpr-unit--minimal.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit--minimal.html.twig
@@ -24,7 +24,7 @@
   {% set card_metas = card_metas|merge([{
       icon: 'clock',
       label: 'Opening hours'|t({}, {'context': 'TPR unit result card'}),
-      content: content.opening_hours|render|striptags|replace({'\n-': ''}),
+      content: content.opening_hours|render|striptags|replace({'\n-': ' '}),
     }]) %}
 {% endif %}
 


### PR DESCRIPTION
# [UHF-9230](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9230)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Remove unnecessary '-' from after-school activity card.

![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/732227/74f8e955-8bcf-4056-9118-29cb18d908be).

The field is a text-field in TPR, so formatting it on Drupal side is a bit fragile. However, with this simple change, the result looks better with current field values.

<img width="611" alt="image" src="https://github.com/City-of-Helsinki/drupal-hdbt/assets/732227/147aa87e-0cd4-423d-98d2-650e9f4ecfe6">

## How to install

* Make sure your KASKO is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9230-after-school-activity-search-card`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* #884


[UHF-9230]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ