### PR TITLE
UHF-9311: Unit search paragraph changes and improvements

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -402,6 +402,19 @@ function _hdbt_preprocess_image_caption(array &$variables, string $entity_type, 
  */
 function hdbt_theme_suggestions_form_element_alter(array &$suggestions, array $variables): void {
   $suggestions[] = $variables['theme_hook_original'] . '__' . $variables['element']['#type'];
+
+  if (isset($variables['element']['#name'])) {
+    $suggestions[] = $variables['theme_hook_original'] . '__' . $variables['element']['#type'] . '__' . str_replace('-', '_', $variables['element']['#name']);
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function hdbt_theme_suggestions_form_element_label_alter(array &$suggestions, array $variables): void {
+  if (isset($variables['element']['#id']) && strpos($variables['element']['#id'], 'edit-unit-search') === 0) {
+    $suggestions[] = $variables['theme_hook_original'] . '__' . 'unit_search';
+  }
 }
 
 /**

--- a/templates/form/form-element-label--unit-search.html.twig
+++ b/templates/form/form-element-label--unit-search.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Theme override for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+  title_display == 'after' ? 'option',
+  title_display == 'invisible' ? 'visually-hidden',
+  required ? 'js-form-required',
+  required ? 'form-required',
+  element['#element_type'] ? element['#element_type'],
+]
+%}
+  <label{{ attributes.addClass(classes) }}>
+    {% if title is not empty %}
+      {{ title }}
+    {% else %}
+      {{ 'Name, address or postal code'|t({}, {'context' : 'Unit search paragraps search input default label'}) }}
+    {% endif %}
+  </label>

--- a/templates/form/text-input/form-element--textfield--unit-search.html.twig
+++ b/templates/form/text-input/form-element--textfield--unit-search.html.twig
@@ -1,0 +1,43 @@
+{% set classes = [
+  'js-form-item',
+  'form-item',
+  'js-form-type-' ~ type|clean_class,
+  'form-item-' ~ name|clean_class,
+  'js-form-item-' ~ name|clean_class,
+  title_display not in ['after', 'before'] ? 'form-no-label',
+  disabled == 'disabled' ? 'form-disabled',
+  errors ? 'form-item--error',
+  'hds-text-input'
+] %}
+
+{% set description_classes = [
+  'description',
+  'hds-text-input__helper-text',
+  description_display == 'invisible' ? 'visually-hidden',
+] %}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ label }}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -985,6 +985,10 @@ msgctxt "Search keyword label"
 msgid "Search term"
 msgstr "Hakusana"
 
+msgctxt "Unit search paragraps search input default label"
+msgid "Name, address or postal code"
+msgstr "Nimi, osoite tai postinumero"
+
 msgctxt "Unit search count singular"
 msgid "result"
 msgstr "tulos"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -982,6 +982,10 @@ msgctxt "Search keyword label"
 msgid "Search term"
 msgstr "Sökord"
 
+msgctxt "Unit search paragraps search input default label"
+msgid "Name, address or postal code"
+msgstr "Namn, adress eller postnummer"
+
 msgctxt "Unit search count singular"
 msgid "result"
 msgstr "resultat"


### PR DESCRIPTION
# [UHF-9311](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9311)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add theme suggestions and templates for the Unit Search paragraph so that the default content can be printed to the form items in the code.

## How to install

* Check installation instructions from the [platform_config PR](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/686).

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check the testing instructions from the [platform_config PR](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/686).
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/686
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/906

[UHF-9311]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ