### PR TITLE
UHF-X: Add original alt attribute to all images

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1165,6 +1165,7 @@ function hdbt_preprocess_responsive_image_formatter(&$variables): void {
 
   // Override alt text if alteration exists.
   if (!empty($variables['item']->altered_alt_text)) {
+    $variables['responsive_image']['#attributes']['data-original-alt'] = $variables['responsive_image']['#attributes']['alt'];
     $variables['responsive_image']['#attributes']['alt'] = $variables['item']->altered_alt_text;
   }
 

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1165,7 +1165,10 @@ function hdbt_preprocess_responsive_image_formatter(&$variables): void {
 
   // Override alt text if alteration exists.
   if (!empty($variables['item']->altered_alt_text)) {
-    $variables['responsive_image']['#attributes']['data-original-alt'] = $variables['responsive_image']['#attributes']['alt'];
+    // Set original alt text to data attribute.
+    if (isset($variables['responsive_image']['#attributes']['alt'])) {
+      $variables['responsive_image']['#attributes']['data-original-alt'] = $variables['responsive_image']['#attributes']['alt'];
+    }
     $variables['responsive_image']['#attributes']['alt'] = $variables['item']->altered_alt_text;
   }
 


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
We currently have no visibility to actual alt attributes.

## What was done
<!-- Describe what was done -->

* This adds original alt to `data-alt-original` attribute so that we can debug it.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_get_original_alt`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards
