### PR TITLE
UHF-9566: Fix deprecated call abs(): Passing null to parameter #1

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1329,9 +1329,8 @@ function hdbt_preprocess_views_view(&$variables): void {
     $variables['pager_items_per_page'] = $variables['view']->pager->options['items_per_page'];
   }
   // Add total rows as a variable.
-  if ($variables['view']->total_rows != NULL) {
-    $variables['total_rows'] = $variables['view']->total_rows;
-  }
+  $variables['total_rows'] = $variables['view']->total_rows ?: 0;
+
   if ($variables['view']->id() == 'service_list') {
     $variables['is_ajax_request'] = \Drupal::request()->isXmlHttpRequest();
   }


### PR DESCRIPTION
# [UHF-9566](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9566)
<!-- What problem does this solve? -->

## What was done

`total_rows` was not defined if `$variables['view']->total_rows` is zero, since `0 == NULL` evaluates to true. This patch ensures that total rows is always defined so templates can use it without checking.

## How to reproduce
Find a view with zero results *OR* find a view and delete its result nodes. Following code triggers the issue:
```twig
{% plural total_rows %}
```

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9566`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/388
  * previous attempt to fix the issue. However, this is a better solution, since it applies to all templates, not just rekry.

[UHF-9566]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ