### PR TITLE
UHF-9440: Print information field for the service channel card if there is any

### DIFF
--- a/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -19,6 +19,10 @@
     </{{ service_channel_heading_level }}>
   {% endif %}
 
+  {% if content.information|render %}
+    <div class="service-channel__information">{{ content.information }}</div>
+  {% endif %}
+
   {% if content.availability_summary|render %}
     <div class="service-channel__availabilities">{{ content.availability_summary }}</div>
   {% endif %}
@@ -67,12 +71,12 @@
     <div class="service-channel__address">{{ content.address }}</div>
   {% endif %}
 
-  {% if entity.requires_authentication.value == 1 or service_channel_eservice_links_new_tab %}
+  {% if entity.requires_authentication.value == 1 or (content.links and service_channel_eservice_links_new_tab and entity.type.value|lower == 'eservice') %}
     <div class="service-channel__extra-information">
       {% if entity.requires_authentication.value == 1 %}
         {{ 'Requires authentication'|t }}.
       {% endif %}
-      {% if content.links and service_channel_eservice_links_new_tab and  entity.type.value|lower == 'eservice' %}
+      {% if content.links and service_channel_eservice_links_new_tab and entity.type.value|lower == 'eservice' %}
         {{ 'The link opens in a new tab'|t({}, {'context': 'Explanation for users that the link opens in a new tab instead of the expected current tab'}) }}.
       {% endif %}
     </div>


### PR DESCRIPTION
# [UHF-9440](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9440)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Print the information field on service channel if it has content.

## How to install
* Check installation instructions from the [TPR PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check testing instructions from the [TPR PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168)
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/703
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/915
* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168

[UHF-9440]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ