### PR TITLE
UHF-9562: Add email to template

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit-contact-information.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit-contact-information.html.twig
@@ -33,18 +33,13 @@
         {% endif %}
       </div>
     {% endif %}
-    {% if unit_email_link and content.email|render %}
-      {% set link_attributes = {
-        'class': [
-          'service-channel__email-link',
-        ],
-      } %}
+    {% if content.email|render %}
       <div class="unit__contact-row unit__contact-row--email">
         <label class="unit__contact-row__label">
           {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'glyph-at'} %}
           {{ 'E-mail'|t }}:
         </label>
-        {{ link(content.email, unit_email_link, link_attributes) }}
+        {{ content.email }}
       </div>
     {% endif %}
     {% if content.phone|render %}


### PR DESCRIPTION
# [UHF-9562](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9562)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add mailto formatter to tpr unit email field.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme & platform config
  * `composer require drupal/hdbt:dev-UHF-9562-unit-email-field`
  * `composer require drupal/helfi_platform_config:dev-UHF-9562-unit-email-field`
* Run `make drush-cr drush-updb`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/722

[UHF-9562]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ