### PR TITLE
UHF-X: Fix unsupported aria-attribute a11y problem

### DIFF
--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -23,13 +23,19 @@
         ]
       } %}
       {% set external_link_title %}
-        {% set button_labelled_by_id = 'button__external-aria-label--' ~ random()|clean_id %}
-        <span class="is-hidden" id="{{ button_labelled_by_id }}">
-          {{- media_iframe_title -}}
-        </span>
-        <span class="hds-button__label" aria-labelledby="{{ button_labelled_by_id }}">
+
+        {# Add alternative screenreader only text to button if it's available #}
+        {% if media_iframe_title %}
+          <span class="visually-hidden">
+            {{- media_iframe_title -}}
+          </span>
+        {% endif %}
+
+        {# If screenreader only text is available, hide default button text from screenreaders #}
+        <span class="hds-button__label" {% if media_iframe_title %}aria-hidden="true"{% endif %}>
           {{- 'See content on external site'|t({}, {'context': 'Cookie compliance'}) -}}
         </span>
+
       {% endset %}
 
       {{ link(external_link_title, media_url, external_link_attributes) }}


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

* Siteimprove found a problem with our fallback iframe links. Aria-attribute aria-labelledby is not supported on non-interactive elements like span that we're using.
* We also have some situations where we do not have accessible link text available, and on these cases screen reader get no proper hint what the button does.

Where the problems appear:
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/6c8abb6e-2185-43ac-81dd-98b57bde000e)

Example of missing accessible text:
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/a561c7d3-8326-49a1-a3c4-cff7309070d5)


## What was done
<!-- Describe what was done -->

* The aria-labelledby was replaced with `aria-hidden="true"` and `class="visually-hidden"`-combination
* An check for the existence of the screenreader only text was added and it now has a fallback mode of regular link text instead of specific screenreader text.

![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/401d6010-9524-4f67-99b3-afb247fd726d)


## How to install

* Make sure your SOTE instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [this page](https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/hammashoito/hammashoitolat#hammashoitolat-kartalla) on your local Sote instance
    * [ ] Check that screen reader text is rendered like this ![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/3c0c0d63-79f9-44c7-b825-4a5f6cef146a)
* [ ] Open [this page](https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/vammaispalvelut/asuminen/asumisyksikot/hyvosen-ryhmakoti#sijainti) on your local Sote instance
    * [ ] Check that the missing screen reader text causes the link to be rendered without it, so that screen readers get a hint what the button does. 
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/09b791e3-83b9-45f6-b91c-4419218b797b)
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation
