### PR TITLE
UHF-9786: Fix missing links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6530,9 +6530,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001605",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
-      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
+      "version": "1.0.30001606",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
       "funding": [
         {
           "type": "opencollective",

--- a/templates/module/helfi_tpr/tpr-errand-service.html.twig
+++ b/templates/module/helfi_tpr/tpr-errand-service.html.twig
@@ -75,7 +75,7 @@
                 } %}
 
               {% endif %}
-              {% if content.information|render %}
+              {% if errand_service_additional_info|render %}
 
                 {% include '@hdbt/component/accordion.twig' with {
                   heading_level: 'h3',

--- a/templates/module/helfi_tpr/tpr-errand-service.html.twig
+++ b/templates/module/helfi_tpr/tpr-errand-service.html.twig
@@ -75,7 +75,7 @@
                 } %}
 
               {% endif %}
-              {% if errand_service_additional_info|render %}
+              {% if errand_service_additional_info|render|striptags|trim is not empty %}
 
                 {% include '@hdbt/component/accordion.twig' with {
                   heading_level: 'h3',


### PR DESCRIPTION
# [UHF-9786](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9786)
<!-- What problem does this solve? -->
The links are not appearing without also defining extra information text.

For example [this Kymp page](https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/pysakointi/yrityspysakointi) has links in [Finnish](https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/pysakointi/yrityspysakointi) and [Swedish](https://www.hel.fi/sv/stadsmiljo-och-trafik/parkering/foretagsparkering), but only Finnish has extra information text and only that accordion is visible:
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/354dfe93-a63e-4557-b238-7d6293c95e2d)
![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/12779317-93d5-43e0-a34f-37c74749c9d4)

## What was done
<!-- Describe what was done -->

* The twig template if-statement was modified to check the actual content of the accordion, thus making the links visible even without the extra information text.

![image](https://github.com/City-of-Helsinki/drupal-hdbt/assets/1191667/3efa5f4b-772c-40d1-80e1-1bcf0de23286)

## How to install

* Make sure your instance (KYMP) is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9786_missing_links`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that [this local page](https://helfi-kymp.docker.so/sv/stadsmiljo-och-trafik/parkering/foretagsparkering#ytterligare-upplysningar-och-lankar) has the links (and accordion) visible as in above screenshot.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation



[UHF-9786]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ