### PR TITLE
UHF-9797 standalone cookie page

### DIFF
--- a/src/js/hds-cc/hds-cc.js
+++ b/src/js/hds-cc/hds-cc.js
@@ -230,7 +230,13 @@ class HdsCookieConsentClass {
     // console.log('#setCookie', cookieData);
     const expiryDate = new Date();
     expiryDate.setDate(expiryDate.getDate() + this.#COOKIE_DAYS);
-    document.cookie = serialize(this.#cookie_name, JSON.stringify(cookieData), { expires: expiryDate });
+    document.cookie = serialize(
+      this.#cookie_name,
+      JSON.stringify(cookieData),
+      {
+        expires: expiryDate,
+        path: '/',
+      });
   }
 
 

--- a/src/js/hds-cc/hds-cc.js
+++ b/src/js/hds-cc/hds-cc.js
@@ -574,6 +574,29 @@ class HdsCookieConsentClass {
   }
 
   /**
+   * Temporary solition to inject CSS styles into the shadow root.
+   * @private
+   * @param {ShadowRoot} shadowRoot - The shadow root element to inject the styles into.
+   * @return {Promise<void>} - A promise that resolves when the styles are injected successfully.
+   * @throws {Error} - If there is an error fetching or injecting the styles.
+   */
+  async #injectCssStyles(shadowRoot) {
+    // TODO: Replace this temporary CSS file hack with proper preprocess CSS inlining
+    // Fetch the external CSS file
+    try {
+      const response = await fetch(this.#TEMP_CSS_PATH);
+      const cssText = await response.text();
+
+      // Create and inject the style
+      const style = document.createElement('style');
+      style.textContent = cssText;
+      shadowRoot.appendChild(style);
+    } catch (error) {
+      throw new Error(`Cookie consent: Failed to load the temporary CSS file solution: '${error}'`);
+    }
+  }
+
+  /**
    * Renders the cookie consent banner.
    * @private
    * @param {string} lang - The language for translations.
@@ -604,19 +627,8 @@ class HdsCookieConsentClass {
     const shadowRoot = bannerContainer.attachShadow({ mode: 'open' });
     this.#shadowRoot = shadowRoot;
 
-    // TODO: Replace this temporary CSS file hack with proper preprocess CSS inlining
-    // Fetch the external CSS file
-    try {
-      const response = await fetch(this.#TEMP_CSS_PATH);
-      const cssText = await response.text();
-
-      // Create and inject the style
-      const style = document.createElement('style');
-      style.textContent = cssText;
-      shadowRoot.appendChild(style);
-    } catch (error) {
-      throw new Error(`Cookie consent: Failed to load the temporary CSS file solution: '${error}'`);
-    }
+    // Inject CSS styles
+    await this.#injectCssStyles(shadowRoot);
 
     const translations = {};
     const translationKeys = getTranslationKeys();

--- a/src/js/hds-cc/hds-cc.js
+++ b/src/js/hds-cc/hds-cc.js
@@ -642,6 +642,9 @@ class HdsCookieConsentClass {
     const container = document.createElement('div');
     container.classList.add('hds-cc__target');
     container.style.all = 'initial';
+    if (!isBanner) {
+      renderTarget.innerHTML = '';
+    }
     renderTarget.prepend(container);
     const shadowRoot = container.attachShadow({ mode: 'open' });
     this.#shadowRoot = shadowRoot;

--- a/src/js/hds-cc/hds-cc.js
+++ b/src/js/hds-cc/hds-cc.js
@@ -275,9 +275,7 @@ class HdsCookieConsentClass {
         const formCheckboxes = form.querySelectorAll('input');
 
         formCheckboxes.forEach(check => {
-          if (acceptedGroupNames.includes(check.dataset.group)) {
-            check.checked = true;
-          }
+          check.checked = acceptedGroupNames.includes(check.dataset.group);
         });
       }
     }

--- a/src/js/hds-cc/hds-cc.js
+++ b/src/js/hds-cc/hds-cc.js
@@ -653,6 +653,13 @@ class HdsCookieConsentClass {
     // Create banner HTML
     shadowRoot.innerHTML += getCookieBannerHtml(translations, groupsHtml);
 
+    // Add button events
+    const cookieButtons = shadowRoot.querySelectorAll('button[type=submit]');
+    const shadowRootForm = shadowRoot.querySelector('form');
+    cookieButtons.forEach(button => button.addEventListener('click', e => {
+      this.#handleButtonEvents(e.target.dataset.approved, shadowRootForm, cookieSettings);
+    }));
+
     // Add scroll-margin-bottom to all elements inside the contentSelector
     const style = document.createElement('style');
     style.innerHTML = `${this.#PAGE_CONTENT_SELECTOR} * {scroll-margin-bottom: calc(var(--hds-cookie-consent-height, -8px) + 8px);}`;
@@ -676,13 +683,6 @@ class HdsCookieConsentClass {
     resizeObserver.observe(bannerHeightElement);
     this.#resizeReference.resizeObserver = resizeObserver;
     this.#resizeReference.bannerHeightElement = bannerHeightElement;
-
-    // Add button events
-    const cookieButtons = shadowRoot.querySelectorAll('button[type=submit]');
-    const shadowRootForm = shadowRoot.querySelector('form');
-    cookieButtons.forEach(button => button.addEventListener('click', e => {
-      this.#handleButtonEvents(e.target.dataset.approved, shadowRootForm, cookieSettings);
-    }));
 
     shadowRoot.querySelector('.hds-cc').focus();
   }

--- a/src/js/hds-cc/template.js
+++ b/src/js/hds-cc/template.js
@@ -13,11 +13,12 @@
  * @param {string} translations.approveRequiredAndSelectedConsents - The text for the "Approve Required and Selected Consents" button.
  * @param {string} translations.approveOnlyRequiredConsents - The text for the "Approve Only Required Consents" button.
  * @param {string} groupsHtml - The HTML for the consent groups.
+ * @param {boolean} isBanner - Indicates if the code is rendered as banner or part of a page.
  * @return {string} The HTML for the cookie banner.
  */
-export function getCookieBannerHtml(translations, groupsHtml) {
+export function getCookieBannerHtml(translations, groupsHtml, isBanner = true) {
   return `
-<div id="hds-cc" class="hds-cc" tabindex="-1" role="region" aria-label="${translations.bannerAriaLabel}">
+<div id="hds-cc" class="hds-cc ${isBanner?'hds-cc--banner':'hds-cc--page'}" tabindex="-1" role="region" aria-label="${translations.bannerAriaLabel}">
   <div class="hds-cc__container">
     <div class="hds-cc__aligner">
 

--- a/src/js/hds-cc/template.js
+++ b/src/js/hds-cc/template.js
@@ -52,11 +52,11 @@ export function getCookieBannerHtml(translations, groupsHtml, isBanner = true) {
         </div>
       </form>
       <div class="hds-cc__buttons">
+        <button type="submit" class="hds-button hds-button--secondary hds-cc__selected-cookies-button" data-approved="selected">
+        <span class="hds-button__label">${translations.approveRequiredAndSelectedConsents}</span>
+        </button>
         <button type="submit" class="hds-button hds-button--secondary hds-cc__all-cookies-button" data-approved="all">
           <span class="hds-button__label">${translations.approveAllConsents}</span>
-        </button>
-        <button type="submit" class="hds-button hds-button--secondary hds-cc__selected-cookies-button" data-approved="selected">
-          <span class="hds-button__label">${translations.approveRequiredAndSelectedConsents}</span>
         </button>
         <button type="submit" class="hds-button hds-button--secondary hds-cc__required-cookies-button" data-approved="required">
           <span class="hds-button__label">${translations.approveOnlyRequiredConsents}</span>

--- a/src/scss/cookie-consent.scss
+++ b/src/scss/cookie-consent.scss
@@ -234,6 +234,10 @@ $base-font-size: 16px;
   // --hds-cc-border-color: #000000;
 }
 
+.hds-cc--page {
+  margin-block: var(--spacing-layout-xs);
+}
+
 $font-path: '../fonts';
 
 /* Webfont: HelsinkiGrotesk-Regular */
@@ -361,37 +365,51 @@ html {
   --common-spacing: var(--spacing-s);
   --focus-outline-color: var(--color-coat-of-arms);
   --outline-width: 3px;
-  // all: initial;
-  bottom: 0;
   color: var(--color-black-90);
   font-family: var(--font-default);
   font-size: var(--fontsize-body-m);
-  left: 0;
-  overscroll-behavior: contain;
-  position: fixed;
-  width: 100vw;
-  z-index: 999;
+
+  &.hds-cc--banner {
+    bottom: 0;
+    left: 0;
+    overscroll-behavior: contain;
+    position: fixed;
+    width: 100vw;
+    z-index: 999;
+  }
+
+  &.hds-cc--page {
+    padding-top: var(--spacing-layout-xs);
+  }
 }
+
 
 
 .hds-cc__container {
   background: var(--color-white);
-  border-top: 8px solid var(--hds-cc-border-color, var(--color-bus));
-  bottom: 0;
-  max-height: 80vh;
-  overflow-y: auto;
-  position: absolute;
-  width: 100%;
-  z-index: 2;
+
+  .hds-cc--banner & {
+    border-top: 8px solid var(--hds-cc-border-color, var(--color-bus));
+    bottom: 0;
+    max-height: 80vh;
+    overflow-y: auto;
+    position: absolute;
+    width: 100%;
+    z-index: 2;
+  }
 }
+
 
 .hds-cc__aligner {
   margin-inline: auto;
   max-width: var(--container-width-xl);
-  padding: var(--spacing-layout-2-xs);
 
-  @media (min-width: 768px) {
-    padding: var(--spacing-layout-s) var(--spacing-layout-xs);
+  .hds-cc--banner & {
+    padding: var(--spacing-layout-2-xs);
+
+    @media (min-width: 768px) {
+      padding: var(--spacing-layout-s) var(--spacing-layout-xs);
+    }
   }
 }
 
@@ -466,7 +484,11 @@ html {
 }
 
 // Animate form open / close
-@include animateheight( '.hds-cc__form', ':not([aria-expanded='true']) + .hds-cc__form', '.hds-cc__form__animator' );
+@include animateheight( '.hds-cc--banner .hds-cc__form', '.hds-cc--banner :not([aria-expanded='true']) + .hds-cc__form', '.hds-cc--banner .hds-cc__form__animator' );
+
+.hds-cc--page .hds-cc__accordion-button--details {
+  display: none;
+}
 
 .hds-cc__groups{
   padding-bottom: var(--spacing-layout-xs);
@@ -491,8 +513,8 @@ html {
 :not([aria-expanded='true']) > .hds-cc__accordion-button-hide,
 [aria-expanded='true'] > .hds-cc__accordion-button-show,
 [aria-controls='hds-cc-form'][aria-expanded='true'] ~ .hds-cc__buttons .hds-cc__all-cookies-button,
-[aria-controls='hds-cc-form']:not([aria-expanded='true']) ~ .hds-cc__buttons .hds-cc__selected-cookies-button,
-.temp {
+.hds-cc--page .hds-cc__all-cookies-button,
+.hds-cc--banner [aria-controls='hds-cc-form']:not([aria-expanded='true']) ~ .hds-cc__buttons .hds-cc__selected-cookies-button {
   display: none;
 }
 

--- a/templates/misc/cookie-container.html.twig
+++ b/templates/misc/cookie-container.html.twig
@@ -16,6 +16,7 @@ window.addEventListener('cookie-consent-changed', function(event) {
         //spacerParentSelector: 'body', // Defaults to 'body'
         //pageContentSelector: 'body', // Defaults to 'body'
         //submitEvent: 'cookie-consent-changed', // If this string is set, triggers a window level event with that string and detail.acceptedGroups before closing banner. If not set, reloads page instead
+        settingsPageSelector: '#hds-cookie-consent-full-page', // If this string is set and matching element is found on page, instead of banner, show a full page cookie settings replacing the matched element.
         tempCssPath: '{{ theme_path }}/dist/css/cookie-consent.min.css', // TODO: Remove this when the real build process can include css files
       }
     };


### PR DESCRIPTION
# [UHF-9797](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9797)
<!-- What problem does this solve? -->
The cookie banner should be able to render itself on a standard page instead of as a banner when conditions are met.

## What was done
<!-- Describe what was done -->

* Cookie banner functionality was extended to support the page rendering

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9797_standalone_cookie_page`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add a snippet like `<p id="hds-cookie-consent-full-page">Keksiasetukset vaativat javascript tuen toimiakseen.</p>` to page, for example to paragraph--text.html.twig so that you can see the code on the page.
* [x] Check that the cookie banner code (cookie-container.html.twig) has `settingsPageSelector: '#hds-cookie-consent-full-page',` set up.
* [x] Verify that cookie banner renders on a page without the text paragraph (landing page) as a normal banner.
    * [x] Check that banner version still hides when cookies are set
* [x] Verify that cookie banner renders on a page with the text paragraph in page.
    * [x] Check that in page version does not get hidden at all
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation


[UHF-9797]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ