### PR TITLE
Test/prod environment needs full path for this url. Fix.

### DIFF
--- a/src/js/react/apps/job-search/containers/SearchMonitorContainer.tsx
+++ b/src/js/react/apps/job-search/containers/SearchMonitorContainer.tsx
@@ -87,7 +87,12 @@ const SearchMonitorContainer = () => {
 
     // Send form to Hakuvahti subscribe service
     const body = JSON.stringify(requestBody);
-    const response = await fetch('/hakuvahti/subscribe', {
+    const { host, pathname } = window.location;
+    let apiPath = `${pathname}/hakuvahti/subscribe`;
+    if (host.includes('docker.so')) {
+      apiPath = '/hakuvahti/subscribe';
+    }
+    const response = await fetch(apiPath, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->
In test/prod, url for hakuvahti endpoint needs full prefixed path, but on local it does not. 

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-x_fix_test_env`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Hakuvahti subscription form works.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
