### PR TITLE
UHF-10201: Hide the alternative languages on the language switcher even if they are active

### DIFF
--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -55,6 +55,7 @@
           {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
           {% set element = 'a' %}
           {% set ariaCurrent = create_attribute({'aria-current': 'true'}) %}
+          {% set classes = classes|merge(['is-disabled']) %}
         {% else %}
           {% set element = 'span' %}
           {% set classes = classes|merge(['is-disabled']) %}


### PR DESCRIPTION
# [UHF-10201](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10201)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Hide the alternative languages on the language switcher even if they are active

## How to install

* Make sure your front page instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10201`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure the language switcher works normally for the three main languages.
* [ ] Switch to some alternative language such as https://helfi-etusivu.docker.so/de and make sure that the language is no longer visible in the language switcher and none of the main languages are highlighted active.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-10201]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ