### PR TITLE
UHF-9741: Update the news archive library to 1.3 so that the old version is removed from cache

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -207,7 +207,7 @@ district-and-project-search:
     - core/drupal
 
 news-archive:
-  version: 1.2
+  version: 1.3
   js:
     dist/js/news-archive.min.js: {
       preprocess: false


### PR DESCRIPTION
# [UHF-9741](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9741)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Update the news archive library to 1.3 so that the old version is removed from cache

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9741_update_news_archive_library`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the news archive works correctly.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-9741]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ