### PR TITLE
UHF-X: Changed the feedback link to point to correct place

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -205,7 +205,7 @@ function hdbt_get_global_url(string $langcode): array {
       'decisions_link_url' => 'https://www.hel.fi/fi/hae-paatoksia',
       'helfi_search_form_url' => 'https://www.hel.fi/haku',
       'error_page_home_link' => 'https://www.hel.fi/fi',
-      'error_page_feedback_link' => 'https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute',
+      'error_page_feedback_link' => 'https://palautteet.hel.fi/fi/',
     ];
   }
   elseif ($langcode == 'sv') {
@@ -214,7 +214,7 @@ function hdbt_get_global_url(string $langcode): array {
       'decisions_link_url' => 'https://www.hel.fi/sv/sok-beslut',
       'helfi_search_form_url' => 'https://www.hel.fi/sok',
       'error_page_home_link' => 'https://www.hel.fi/sv',
-      'error_page_feedback_link' => 'https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback',
+      'error_page_feedback_link' => 'https://palautteet.hel.fi/sv/',
     ];
   }
   else {
@@ -223,7 +223,7 @@ function hdbt_get_global_url(string $langcode): array {
       'decisions_link_url' => 'https://www.hel.fi/en/search-decisions',
       'helfi_search_form_url' => 'https://www.hel.fi/search',
       'error_page_home_link' => 'https://www.hel.fi/en',
-      'error_page_feedback_link' => 'https://www.hel.fi/helsinki/en/administration/participate/feedback',
+      'error_page_feedback_link' => 'https://palautteet.hel.fi/en/',
     ];
   }
   return $urls;


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed feedback links to point to correct place

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_fix_404_feedback_link`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure 404 page feedback links point to correct place now.
* [ ] Check that code follows our standards

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been included in this PR
