### PR TITLE
UHF-10469: Revert news archive from index to database based

### DIFF
--- a/templates/module/helfi-news-item/views-view--news-archive.html.twig
+++ b/templates/module/helfi-news-item/views-view--news-archive.html.twig
@@ -9,6 +9,7 @@
 {% else %}
   {% set results_term_plural_value = ' ' ~ 'items'|t({}, {'context' : 'News archive fallback count plural'}) %}
 {% endif %}
+
 <div class="unit-search__results">
   <h3 class="unit-search__count-container">
     {%- if total_rows -%}

--- a/templates/module/helfi-news-item/views-view--news-archive.html.twig
+++ b/templates/module/helfi-news-item/views-view--news-archive.html.twig
@@ -9,7 +9,6 @@
 {% else %}
   {% set results_term_plural_value = ' ' ~ 'items'|t({}, {'context' : 'News archive fallback count plural'}) %}
 {% endif %}
-
 <div class="unit-search__results">
   <h3 class="unit-search__count-container">
     {%- if total_rows -%}

--- a/templates/paragraphs/paragraph--news-archive.html.twig
+++ b/templates/paragraphs/paragraph--news-archive.html.twig
@@ -14,7 +14,7 @@
   %}
     {% block component_content %}
       <div id="helfi-etusivu-news-search">
-        {{ drupal_view('news_archive_index', 'news_archive_index_block') }}
+        {{ drupal_view('news_archive', 'news_archive_block') }}
       </div>
     {% endblock component_content %}
   {% endembed %}


### PR DESCRIPTION
# [UHF-10469](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10469)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change news archive fallback and rss views to use drupal database instead of elastic index to make the rss filtering work correctly

## How to install

* Check installation instructions from the front page instance PR: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/683

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check testing instructions from the front page instance PR: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/683
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1043
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/683

[UHF-10469]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ