### PR TITLE
UHF-10424: Fix match statement in hdbt_preprocess_feed_icon

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -475,9 +475,9 @@ function hdbt_preprocess_feed_icon(&$variables): void {
     return;
   }
 
-  $variables['title'] = match(strtolower($variables['title'])) {
-    'news', 'nyheter', 'uutiset' => t('all news', [], ['context' => 'Feed icon altered title'])
-  };
+  if (in_array(strtolower($variables['title']), ['news', 'nyheter', 'uutiset'])) {
+    $variables['title'] = t('all news', [], ['context' => 'Feed icon altered title']);
+  }
 }
 
 /**


### PR DESCRIPTION
Päätökset triggers hdbt_preprocess_feed_icon such that `title` is not in match statement. This throws an exception.