### PR TITLE
Footer Js libraries should not have dependencies to header libraries

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -133,7 +133,6 @@ closable_surveys:
 
 tabbable:
   version: 6.2.0
-  header: true
   js:
     dist/js/tabbable/tabbable.min.js: {
       minified: true
@@ -141,7 +140,6 @@ tabbable:
 
 focus-trap:
   version: 7.5.4
-  header: true
   js:
     dist/js/focus-trap/focus-trap.min.js: {
       minified: true


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Js libraries are broken in [etusivu test](https://www.test.hel.ninja/fi) for anonymous users. I believe this should fix the issue.

Core [moves dependencies of header library to header](https://github.com/drupal/drupal/blob/10.3.x/core/lib/Drupal/Core/Asset/AssetResolver.php#L281-L284). However, this does not appear to happen to other way, dependencies of footer libraries are not moved to footer. [JsAssetController](https://github.com/drupal/drupal/blob/10.3.x/core/modules/system/src/Controller/JsAssetController.php#L53-L57) loads only the libraries in current scope (header or footer). If some dependencies are missing, the asset hashes do not match, and the asset [controller triggers a redirect response](https://github.com/drupal/drupal/blob/10.3.x/core/modules/system/src/Controller/AssetControllerBase.php#L204-L215). [Redirect response paths](https://github.com/drupal/drupal/blob/10.3.x/core/modules/system/src/Controller/AssetControllerBase.php#L210) do not go through `hook_file_url`, so our proxy settings don't get triggered.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X-footer-js-libraries`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that all Js loads correctly
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
