### PR TITLE
UHF-X: Fix tag-list.twig role group quotes

### DIFF
--- a/templates/misc/tag-list.twig
+++ b/templates/misc/tag-list.twig
@@ -2,7 +2,7 @@
 {% set role = '' %}
 {% if inside_card %}
   {% set element = 'div' %}
-  {% set role = 'role="group"' %}
+  {% set role %}role="group"{% endset %}
 {% endif %}
 
 {% if type == 'interactive' %}


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
* Siteimprove [found bunch of broken](https://my2.siteimprove.com/Accessibility/398510/50178268819/NextGen/Issue/1?query=/fi/&conformance=&pageSegments=&ruleName=sia-r110&ruleId=110&issueKind=1&exceptTags=1,2&siteTarget.conformanceLevels=0,1,3,4) `role=&nbsp;group&nbsp;`-attributes due to twig parsing in Sote and Rekry instances
![image](https://github.com/user-attachments/assets/86564df8-305f-44ae-91ed-24e22bf88b3c)
![image](https://github.com/user-attachments/assets/f96cbb06-ecf0-4084-bf39-fac72d9de488)


## What was done
<!-- Describe what was done -->

* Syntax was fixed

## How to install

* Make sure your Rekry or Sote instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that `role="group"` attribute has proper quotes (use view source, dev tools renders the broken as `role=""group""` )
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation
