### PR TITLE
UHF-8650: Switch embeds and matomo to use hds cookie banner

### DIFF
--- a/src/js/matomo.js
+++ b/src/js/matomo.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line func-names
 (function ($, Drupal) {
   function loadMatomoAnalytics() {
-    /** 
-     * If the queryparameter is found, the script will be loaded 
+    /**
+     * If the queryparameter is found, the script will be loaded
      * regardless of cookie consents etc.
      */
     const useJSAPI = window.location.search === '?9mt5bfb2bGk=';
@@ -40,12 +40,8 @@
       })();
     }
 
-    if (!useJSAPI && typeof Drupal.eu_cookie_compliance === 'undefined') {
-      return;
-    }
-
     // Load Matomo only if statistics cookies are allowed.
-    if (!useJSAPI && Drupal.eu_cookie_compliance.hasAgreed('statistics')) {
+    if (!useJSAPI && window && window.hds.cookieConsent && window.hds.cookieConsent.getConsentStatus(['statistics'])) {
       // Matomo Tag Manager
       // eslint-disable-next-line no-multi-assign
       const _mtm = (window._mtm = window._mtm || []);
@@ -63,11 +59,11 @@
     }
   }
 
-  // Load when cookie settings are changed.
-  $(document).on('eu_cookie_compliance.changeStatus', loadMatomoAnalytics());
-
-  // Load on page load.
-  $(document).ready(loadMatomoAnalytics);
+  if (window.hds.cookieConsent) {
+    loadMatomoAnalytics();
+  } else {
+    $(document).on('hds_cookieConsent_ready', loadMatomoAnalytics);
+  }
 })(jQuery, Drupal);
 
 // Clean/refactor this file when the testing phase is done

--- a/templates/misc/embedded-content-cookie-compliance.twig
+++ b/templates/misc/embedded-content-cookie-compliance.twig
@@ -48,6 +48,8 @@
           'hds-button',
           'hds-button--secondary',
         ],
+        'data-cookie-consent-groups': 'preferences, statistics',
+        'onclick': 'window.hdsCookieConsentClickEvent(event, this)',
       } %}
       {{ link(link_title, privacy_policy_url, link_attributes) }}
 


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->

* We want to use new cookie banner

## What was done
<!-- Describe what was done -->

* Embeds were switched to new banner
* matomo was switched to new banner, but I was unable to test it.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8650_cookie_banner_activation`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that embeds: videos, maps, charts work with new banner and banner opens on click
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/826

[UHF-8650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ