### PR TITLE
UHF-10542: Update maintenance page links

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1541,20 +1541,20 @@ function hdbt_preprocess_maintenance_page(&$variables): void {
   // accordingly.
   switch ($variables['language']->getId()) {
     case 'fi':
-      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/fi';
-      $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute';
+      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/fi';
+      $variables['maintenance_page_feedback_link'] = 'https://palautteet.hel.fi/fi';
       $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/fi.html';
       break;
 
     case 'sv':
-      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/sv';
-      $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback';
+      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/sv';
+      $variables['maintenance_page_feedback_link'] = 'https://palautteet.hel.fi/sv';
       $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/sv.html';
       break;
 
     default:
-      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/helsinki/en';
-      $variables['maintenance_page_feedback_link'] = 'https://www.hel.fi/helsinki/en/administration/participate/feedback';
+      $variables['maintenance_page_home_link'] = 'https://www.hel.fi/en';
+      $variables['maintenance_page_feedback_link'] = 'https://palautteet.hel.fi/en';
       $variables['maintenance_page_copy_link'] = 'https://kopio.hel.fi/en.html';
       break;
   }


### PR DESCRIPTION
# [UHF-10542](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10542)
<!-- What problem does this solve? -->
* Maintenance page links need to be updated

## What was done
<!-- Describe what was done -->

* Links were updated

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10542_maintenance_links`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Set your instance to maintenance mode from /admin/config/development/maintenance
* [ ] Open the maintenance page in incognito mode
* [ ] Check that links point to correct places
* [ ] Check all language versions: fi, sv, en, (others fall back to en-language)
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation

