### PR TITLE
UHF-8833: Change Askem-features no-cookies texts

### DIFF
--- a/templates/module/helfi_platform_config/react-and-share.html.twig
+++ b/templates/module/helfi_platform_config/react-and-share.html.twig
@@ -15,7 +15,7 @@
     <h2>{{ 'Feedback buttons cannot be displayed'|t({}, {'context': 'React & Share cookie compliance'}) }}</h2>
     <p>
       {% trans with {'context': 'React & Share cookie compliance'} %}
-        To use this feature, you must accept cookies from the site. You can provide feedback on this page by enabling statistics-related cookies.
+        Enabling cookies that collect statistics will allow you to share your input.
       {% endtrans %}
     </p>
     <div class="buttons">

--- a/templates/module/helfi_platform_config/react-and-share.html.twig
+++ b/templates/module/helfi_platform_config/react-and-share.html.twig
@@ -12,7 +12,7 @@
 <div class="react-and-share-cookie-compliance js-react-and-share-cookie-compliance" style="display: none;">
   <div class="message">
     {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'alert-circle-fill'} %}
-    <h2>{{ 'Feedback buttons cannot be displayed'|t({}, {'context': 'React & Share cookie compliance'}) }}</h2>
+    <h2>{{ 'Would you like to give feedback on this page?'|t({}, {'context': 'React & Share cookie compliance'}) }}</h2>
     <p>
       {% trans with {'context': 'React & Share cookie compliance'} %}
         Enabling cookies that collect statistics will allow you to share your input.

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -1311,3 +1311,11 @@ msgstr "Julkaistu"
 msgctxt "The helper text before the news article changed timestamp"
 msgid "updated"
 msgstr "päivitetty"
+
+msgctxt "React & Share cookie compliance"
+msgid "Would you like to give feedback on this page?"
+msgstr "Haluatko antaa meille palautetta tästä sivusta?"
+
+msgctxt "React & Share cookie compliance"
+msgid "Enabling cookies that collect statistics will allow you to share your input."
+msgstr "Pääset antamaan palautetta, jos sallit evästeasetuksista tilastointiin liittyvät evästeet."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -1313,3 +1313,11 @@ msgstr "Publicerad"
 msgctxt "The helper text before the news article changed timestamp"
 msgid "updated"
 msgstr "uppdaterad"
+
+msgctxt "React & Share cookie compliance"
+msgid "Would you like to give feedback on this page?"
+msgstr "Vill du ge oss feedback om denna sida?"
+
+msgctxt "React & Share cookie compliance"
+msgid "Enabling cookies that collect statistics will allow you to share your input."
+msgstr "Du kan ge oss feedback genom att aktivera statistikrelaterade cookies."


### PR DESCRIPTION
# [UHF-8833](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8833)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the texts that are displayed on the Askem block when cookies are not allowed by the user.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8833`
* Run `make drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to any page on your testing instance that has the Askem (React & Share) block enabled and make sure you don't have cookies approved.
* [x] The block should now say:
FI
Haluatko antaa meille palautetta tästä sivusta?
Pääset antamaan palautetta, jos sallit evästeasetuksista tilastointiin liittyvät evästeet.
SV
Vill du ge oss feedback om denna sida?
Du kan ge oss feedback genom att aktivera statistikrelaterade cookies.
EN
Would you like to give feedback on this page?
Enabling cookies that collect statistics will allow you to share your input.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

[UHF-8833]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ