### PR TITLE
UHF-8650 Pre cleaning

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -74,7 +74,6 @@ embedded-content-cookie-compliance:
     - core/jquery
     - core/drupal
     - core/drupalSettings
-    - eu_cookie_compliance/eu_cookie_compliance
 
 global-styling:
   version: 1.x
@@ -107,7 +106,6 @@ matomo:
   dependencies:
   - core/drupal
   - core/jquery
-  - eu_cookie_compliance/eu_cookie_compliance
 
 closable_announcements:
   version: 1.1

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1049,6 +1049,32 @@ function hdbt_preprocess_paragraph__news_archive(&$variables) {
 }
 
 /**
+ * Implements hook_library_info_alter().
+ */
+function hdbt_library_info_alter(array &$libraries, string $extension): void {
+  // Add the "eu_cookie_compliance/eu_cookie_compliance" library as a
+  // dependency for the matomo and embedded content libraries if the
+  // EU Cookie compliance module is enabled.
+  if (
+    $extension !== 'hdbt' ||
+    !\Drupal::moduleHandler()->moduleExists('eu_cookie_compliance')
+  ) {
+    return;
+  }
+
+  $dependent_libraries = [
+    'matomo',
+    'embedded-content-cookie-compliance',
+  ];
+
+  foreach ($dependent_libraries as $dependent_library) {
+    if (isset($libraries[$dependent_library])) {
+      $libraries[$dependent_library]['dependencies'][] = 'eu_cookie_compliance/eu_cookie_compliance';
+    }
+  }
+}
+
+/**
  * Set site information as variables for templates.
  *
  * @param array $variables


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change the way to load EU cookie compliance libraries to surpress the "The following theme is missing from the file system: eu_cookie_compliance".

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8650_pre_cleaning`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the EU cookie compliance libraries gets loaded as before.
* [ ] Check that code follows our standards



[UHF-8650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ