### PR TITLE
Check exception type

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -25,6 +25,7 @@ use Drupal\menu_link_content\Plugin\Menu\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 use Drupal\views\ViewExecutable;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
  * Retrieve possible theme color palette override.
@@ -71,9 +72,7 @@ function hdbt_preprocess_html(&$variables): void {
     ->getCurrentRequest()?->attributes->get('exception');
 
   // Check if the page is error-page and add class error-page for the body.
-  if (
-    $page_status?->getStatusCode() > 400
-  ) {
+  if ($page_status instanceof HttpExceptionInterface && $page_status->getStatusCode() > 400) {
     $variables['attributes']['class'][] = 'error-page';
   }
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

This code:

```
Drupal::requestStack()->getCurrentRequest()?->attributes->get('exception');
```

returns the raw exception if maintenance mode is enabled, which causes `->getStatusCode()` to fail.

This resolves Sentry issue: https://sentry.hel.fi/organizations/city-of-helsinki/issues/36088.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X-fix-sentry-error`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that 404 page works.
* [ ] Check that 404 page does not crash when maintenance mode is enabled.
* [ ] Check that code follows our standards.
