### PR TITLE
UHF-10973: Cache in _hdbt_set_image_style

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Template\Attribute;
@@ -1150,19 +1151,21 @@ function _hdbt_set_image_style(array &$variables, string $entity_type, string $i
     $entity->{$image}->entity->hasField('field_media_image') &&
     !$entity->{$image}->entity->field_media_image->first()->isEmpty()
   ) {
-    /** @var \Drupal\file\FileInterface $file */
-    $file = $entity->{$image}->entity;
+    /** @var \Drupal\media\MediaInterface $media */
+    $media = $entity->{$image}->entity;
 
-    // Make sure we load the correct file translation, otherwise
+    // Make sure we load the correct media translation, otherwise
     // hdbt_preprocess_responsive_image_formatter() will receive an empty
     // 'altered_image_style' value for translated media entities.
-    if ($file->hasTranslation($variables['language']->getId())) {
-      $file = $file->getTranslation($variables['language']->getId());
+    if ($media->hasTranslation($variables['language']->getId())) {
+      $media = $media->getTranslation($variables['language']->getId());
     }
     // Set altered_image_style variable based on modified image style
     // for the responsive image preprocesses.
     // @phpstan-ignore-next-line
-    $file->field_media_image->first()->altered_image_style = $image_style;
+    $media->field_media_image->first()->altered_image_style = $image_style;
+    // @phpstan-ignore-next-line
+    $media->field_media_image->first()->altered_cache_tags = $entity->getCacheTags();
   }
 }
 
@@ -1196,6 +1199,13 @@ function hdbt_preprocess_responsive_image_formatter(&$variables): void {
   // Override responsive image style if alteration exists.
   if (!empty($variables['item']->altered_image_style)) {
     $variables['responsive_image']['#responsive_image_style_id'] = $variables['item']->altered_image_style;
+  }
+
+  if (!empty($variables['item']->altered_cache_tags)) {
+    $variables['responsive_image']['#cache']['tags'] = Cache::mergeTags(
+       $variables['item']->altered_cache_tags,
+       $variables['responsive_image']['#cache']['tags'] ?? []
+     );
   }
 
   $image_style = array_key_exists('#responsive_image_style_id', $variables['responsive_image'])


### PR DESCRIPTION
# [UHF-10973](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10973)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Handle cache tags in `_hdbt_set_image_style`.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10973`
* Run `make drush-cr`
* Make sure cache is not disabled in `local.{settings.php,services.yml}`.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Changing `field_image_gallery_ratio` in image gallery paragraph works without clearing caches.
* [x] Changing `field_original_aspect_ratio` in image paragraph works without clearing caches.
* [ ] Changing `field_hero_design` in hero paragraph works without clearing caches.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10973]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ