### PR TITLE
UHF-X: Fix webmanifest favicon url

### DIFF
--- a/src/images/favicon/manifest.webmanifest
+++ b/src/images/favicon/manifest.webmanifest
@@ -2,8 +2,8 @@
   "short_name": "hel.fi",
   "name": "Helsingin kaupunki",
   "icons": [
-    { "src": "/favicon-192x192.png", "type": "image/png", "sizes": "192x192" },
-    { "src": "/favicon-512x512.png", "type": "image/png", "sizes": "512x512" }
+    { "src": "https://www.hel.fi/etusivu-assets/themes/contrib/hdbt/src/images/favicon/favicon-192x192.png", "type": "image/png", "sizes": "192x192" },
+    { "src": "https://www.hel.fi/etusivu-assets/themes/contrib/hdbt/src/images/favicon/favicon-512x512.png", "type": "image/png", "sizes": "512x512" }
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
We get favicon errors on main site due to urls being wrong

## What was done
<!-- Describe what was done -->

* Relative webmanifest file was fixed to be static

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_webmanifest_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that favicons from webmanifest are no longer 404
* [ ] Check that code follows our standards
