### PR TITLE
UHF-10773: Make the popular services templates reusable

### DIFF
--- a/templates/field/field--paragraph--field-service-links--popular-service-item.html.twig
+++ b/templates/field/field--paragraph--field-service-links--popular-service-item.html.twig
@@ -1,7 +1,7 @@
 {% if items is not empty %}
-  <ul class="popular-service-item__links">
-    {% for item in items %}
-      <li class="popular-service-item__link-wrapper">{{ item.content }}</li>
-    {% endfor %}
-  </ul>
+  {% embed "@hdbt/misc/popular-service-links.twig" with { items: items } %}
+    {% block link %}
+      {{ item.content }}
+    {% endblock %}
+  {% endembed %}
 {% endif %}

--- a/templates/misc/popular-service-item.twig
+++ b/templates/misc/popular-service-item.twig
@@ -1,0 +1,6 @@
+<div class="popular-service-item">
+  <h3 class="popular-service-item__title">{{ title }}</h3>
+  {% block links %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/misc/popular-service-links.twig
+++ b/templates/misc/popular-service-links.twig
@@ -1,0 +1,11 @@
+{% if items is not empty %}
+  <ul class="popular-service-item__links">
+    {% for item in items %}
+      <li class="popular-service-item__link-wrapper">
+        {% block link %}
+          {{ link }}
+        {% endblock %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/templates/paragraphs/paragraph--popular-service-item.html.twig
+++ b/templates/paragraphs/paragraph--popular-service-item.html.twig
@@ -1,4 +1,5 @@
-<div class="popular-service-item">
-  <h3 class="popular-service-item__title">{{ content.field_service_title }}</h3>
-  {{ content.field_service_links }}
-</div>
+{% embed "@hdbt/misc/popular-service-item.twig" with { title: content.field_service_title } %}
+  {% block links %}
+    {{ content.field_service_links }}
+  {% endblock links %}
+{% endembed %}


### PR DESCRIPTION
# [UHF-10773](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10773)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Make the popular services templates reusable for Helsinki near you page purposes.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10773`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure that the popular services paragraph still works normally and you can use it without any errors.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1132
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/793


[UHF-10773]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ