### PR TITLE
UHF-11427: Updating accordion library version

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -6,7 +6,7 @@ desktop-menu-toggle:
     }
 
 accordion:
-  version: 1.5
+  version: 1.6
   js:
     dist/js/accordion.min.js: {
       weight: -50,


### PR DESCRIPTION
# [UHF-11427](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11427)
A follow up on #1186 to update the accordion library version. Without it varnish keeps serving the old version.

## What was done

* Accordion library version was updated

## How to install

* Make sure your `drupal-helfi-sote`-instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11427_update_library_version`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to a page with accordions, like https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/asiakkaan-tiedot-ja-oikeudet/odotusajat-ja-asiakaskokemus
* [x] Check the html source that accordion script is loaded with the right version query string: `/terveys-assets/themes/contrib/hdbt/dist/js/accordion.min.js?v=1.6` 
* [x] Check that code follows our standards

## Continuous documentation

* [x] This change doesn't require updates to the documentation


[UHF-11427]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ