### PR TITLE
UHF-11231: Update school search library version to get changes past caches

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -214,7 +214,7 @@ event-list:
     - core/drupal
 
 school-search:
-  version: 1.5.1
+  version: 1.5.2
   js:
     dist/js/school-search.min.js: {
       preprocess: false,


### PR DESCRIPTION
# [UHF-11231](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11231)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Update school search library version to get changes past caches

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11231`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that changes are getting past caches now.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-11231]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ