### PR TITLE
Mark modules D11 compatable

### DIFF
--- a/hdbt.info.yml
+++ b/hdbt.info.yml
@@ -3,7 +3,7 @@ description: Base theme for Helsinki Drupal instances.
 type: theme
 base theme: stable9
 tags: sub-theme
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 'interface translation project': hdbt
 'interface translation server pattern': themes/contrib/hdbt/translations/%language.po
 


### PR DESCRIPTION
This change was made with command: sed -i '' 's/\^9 || \^10/^10 || ^11/g' **/*.yml

# [UHF-11071](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11071)
<!-- What problem does this solve? -->

[UHF-11071]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ