### PR TITLE
UHF-11233: Changed päätökset link to be external

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -164,7 +164,7 @@ function hdbt_get_global_url(string $langcode): array {
   if ($langcode == 'fi') {
     $urls = [
       'events_link_url' => 'https://tapahtumat.hel.fi/fi/',
-      'decisions_link_url' => 'https://www.hel.fi/fi/hae-paatoksia',
+      'decisions_link_url' => 'https://paatokset.hel.fi/fi/asia',
       'helfi_search_form_url' => 'https://www.hel.fi/haku',
       'error_page_home_link' => 'https://www.hel.fi/fi',
       'error_page_feedback_link' => 'https://palautteet.hel.fi/fi/',
@@ -173,7 +173,7 @@ function hdbt_get_global_url(string $langcode): array {
   elseif ($langcode == 'sv') {
     $urls = [
       'events_link_url' => 'https://tapahtumat.hel.fi/sv',
-      'decisions_link_url' => 'https://www.hel.fi/sv/sok-beslut',
+      'decisions_link_url' => 'https://paatokset.hel.fi/sv/arende',
       'helfi_search_form_url' => 'https://www.hel.fi/sok',
       'error_page_home_link' => 'https://www.hel.fi/sv',
       'error_page_feedback_link' => 'https://palautteet.hel.fi/sv/',
@@ -182,7 +182,7 @@ function hdbt_get_global_url(string $langcode): array {
   else {
     $urls = [
       'events_link_url' => 'https://tapahtumat.hel.fi/en',
-      'decisions_link_url' => 'https://www.hel.fi/en/search-decisions',
+      'decisions_link_url' => 'https://paatokset.hel.fi/en/case',
       'helfi_search_form_url' => 'https://www.hel.fi/search',
       'error_page_home_link' => 'https://www.hel.fi/en',
       'error_page_feedback_link' => 'https://palautteet.hel.fi/en/',


### PR DESCRIPTION
# [UHF-11233](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11233)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed "Hae päätöksiä" link to be external in search bar


## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11233`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure the "Hae päätöksiä" link in the search bar works on all three languages and that there is an external link icon
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR


[UHF-11233]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ