### PR TITLE
UHF-11431 Added += values to fix missing frontpage instance url

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1072,6 +1072,7 @@ function _hdbt_set_site_information(array &$variables) {
     catch (\Exception $e) {
       // Set Etusivu absolute url as variable.
       $values['frontpage_instance_url'] = Url::fromUri("https://www.hel.fi/$language_id/");
+      $variables += $values;
       return;
     }
 


### PR DESCRIPTION
# [UHF-11431](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11431)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed site information function

## How to install

* Make sure your Avustukset instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X-frontpage-url-fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure that the city of Helsinki link has an url that goes to frontpage instance and doesn't cause an error
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR


[UHF-11431]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ