### PR TITLE
UHF-10494: Added h2 tag for unit search title

### DIFF
--- a/templates/component/unit-search.twig
+++ b/templates/component/unit-search.twig
@@ -14,7 +14,7 @@
 
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
-  {{ title }}
+  <h2>{{ title }}</h2>
   {{ title_suffix }}
 
   {% if header %}


### PR DESCRIPTION
# [UHF-10494](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10494)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added h2 for unit search title

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10494`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Instructions in KASKO pr
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/813


[UHF-10494]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ