### PR TITLE
UHF-11292: Added check if link_title is already set

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1735,6 +1735,7 @@ function hdbt_preprocess_paragraph__event_list(&$variables): void {
   $variables['#attached']['drupalSettings']['helfi_events']['imagePlaceholder'] = twig_render_template(
     $extensionPathResolver->getPath('theme', 'hdbt') . '/templates/misc/image-placeholder.twig',
     [
+      'directory' => 'themes/custom/hdbt',
       'image_placeholder' => 'calendar-clock',
       'theme_hook_original' => '',
     ]

--- a/templates/misc/feed-icon.html.twig
+++ b/templates/misc/feed-icon.html.twig
@@ -11,9 +11,11 @@
  *   - class: HTML classes to be applied to the feed link.
  */
 #}
-{% set link_title %}
-  {{ 'Subscribe to @title as RSS feed'|t({'@title': title|lower}, {'context': 'Default feed link text'}) }}
-{% endset %}
+{% if not link_title %}
+  {% set link_title %}
+    {{ 'Subscribe to @title as RSS feed'|t({'@title': title|lower}, {'context': 'Default feed link text'}) }}
+  {% endset %}
+{% endif %}
 {% set link_attributes = {
   'class': [
     'feed-link',

--- a/templates/misc/feed-icon.html.twig
+++ b/templates/misc/feed-icon.html.twig
@@ -11,7 +11,7 @@
  *   - class: HTML classes to be applied to the feed link.
  */
 #}
-{% if not link_title %}
+{% if link_title is not defined %}
   {% set link_title %}
     {{ 'Subscribe to @title as RSS feed'|t({'@title': title|lower}, {'context': 'Default feed link text'}) }}
   {% endset %}


### PR DESCRIPTION
# [UHF-11292](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11292)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added check if link_title already is set for feed icon (makes it possible to pass it as a variable)

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11292`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See instructions in KYMP
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1069


[UHF-11292]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ