### PR TITLE
UHF-11629: Add placeholder template for org chart

### DIFF
--- a/templates/paragraphs/paragraph--org-chart.html.twig
+++ b/templates/paragraphs/paragraph--org-chart.html.twig
@@ -1,0 +1,16 @@
+{% block paragraph %}
+  {% embed "@hdbt/misc/component.twig" with
+    {
+      component_classes: [ 'component--org-chart' ],
+      component_title: content.field_org_chart_title,
+      component_description: content.field_org_chart_desc,
+    }
+  %}
+    {% block component_content %}
+
+      {# TODO: UHF-11178 #}
+      {{ org_chart_data }}
+
+    {% endblock component_content %}
+  {% endembed %}
+{% endblock paragraph %}


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Adds placeholder tepmplate for org chart component. This will be improved in https://helsinkisolutionoffice.atlassian.net/browse/UHF-11178.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/955
