### PR TITLE
UHF-11284: Change website information row on TPR Units

### DIFF
--- a/templates/module/helfi_tpr/tpr-unit-contact-information.html.twig
+++ b/templates/module/helfi_tpr/tpr-unit-contact-information.html.twig
@@ -82,10 +82,10 @@
     {% if content.www|render and show_www == true %}
       <div class="unit__contact-row unit__contact-row--www">
         <label class="unit__contact-row__label">
-          {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'arrow-right'} %}
-          {{ 'Website link'|t }}:
+          {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'link'} %}
+          {{ 'Website'|t({}, {'context': 'TPR unit contact information website label'}) }}:
         </label>
-        {{ content.www }}
+        {{ link('Go to the website'|t({}, {'context': 'TPR unit contact information website link'}), entity.getWebsiteUrl()) }}
       </div>
     {% endif %}
     {% if content.address|render %}

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -800,6 +800,14 @@ msgctxt "TPR unit contact information service language"
 msgid "Service language"
 msgstr "Palvelukieli"
 
+msgctxt "TPR unit contact information website label"
+msgid "Website"
+msgstr "Verkkosivut"
+
+msgctxt "TPR unit contact information website link"
+msgid "Go to the website"
+msgstr "Siirry verkkosivuille"
+
 msgctxt "TPR unit contact information HSL Journey Planner link"
 msgid "Show the route in the HSL Journey Planner"
 msgstr "Näytä reitti HSL-reittioppaassa"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -798,6 +798,14 @@ msgctxt "TPR unit contact information service language"
 msgid "Service language"
 msgstr "Servicespråk"
 
+msgctxt "TPR unit contact information website label"
+msgid "Website"
+msgstr "Webbplats"
+
+msgctxt "TPR unit contact information website link"
+msgid "Go to the website"
+msgstr "Gå till webbplatsen"
+
 msgctxt "TPR unit contact information HSL Journey Planner link"
 msgid "Show the route in the HSL Journey Planner"
 msgstr "Visa rutten i HRT:s reseplaneraren"


### PR DESCRIPTION
# [UHF-11284](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11284)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the label, icon and link text in TPR Unit contact information on Unit page. 

## How to install

* Check installation instructions from the [helfi_platform_config PR](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/975).

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the [helfi_platform_config PR](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/975).
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/975 
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1276

[UHF-11284]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ