### PR TITLE
UHF-10628: 

### DIFF
--- a/hdbt.libraries.yml
+++ b/hdbt.libraries.yml
@@ -219,7 +219,7 @@ language-toast:
     - hdbt/nav-toggle
 
 event-list:
-  version: 1.4.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/linkedevents.min.js: {
       preprocess: false,
@@ -231,7 +231,7 @@ event-list:
     - core/drupal
 
 school-search:
-  version: 1.5.4
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/school-search.min.js: {
       preprocess: false,
@@ -244,7 +244,7 @@ school-search:
 # Load the Hyphenopoly library loader javascript separately to make sure
 # the global hyphenopoly object is defined before trying to configure it.
 hyphenopoly-loader:
-  version: 6.0.0
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   header: true
   js:
     dist/js/hyphenopoly/Hyphenopoly_Loader.js: {
@@ -254,7 +254,7 @@ hyphenopoly-loader:
     }
 
 hyphenopoly:
-  version: 6.0.0
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   header: true
   js:
     dist/js/hyphenopoly_settings.min.js: {
@@ -266,7 +266,7 @@ hyphenopoly:
     - hdbt/hyphenopoly-loader
 
 job-search:
-  version: 1.8.5
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/job-search.min.js: {
       preprocess: false,
@@ -277,7 +277,7 @@ job-search:
     - core/drupal
 
 district-and-project-search:
-  version: 1.3.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/district-and-project-search.min.js: {
       preprocess: false,
@@ -288,7 +288,7 @@ district-and-project-search:
     - core/drupal
 
 news-archive:
-  version: 1.3.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/news-archive.min.js: {
       preprocess: false,
@@ -299,7 +299,7 @@ news-archive:
     - core/drupal
 
 search-helper:
-  version: 1.x
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/search-helper.min.js: {
       minified: true
@@ -316,7 +316,7 @@ table-figcaption:
     - core/once
 
 health-station-search:
-  version: 1.3.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/health-station-search.min.js: {
       preprocess: false,
@@ -327,7 +327,7 @@ health-station-search:
     - core/drupal
 
 maternity-and-child-health-clinic-search:
-  version: 1.2.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/maternity-and-child-health-clinic-search.min.js: {
       preprocess: false,
@@ -338,7 +338,7 @@ maternity-and-child-health-clinic-search:
     - core/drupal
 
 ploughing-schedule:
-  version: 1.0.3
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/ploughing-schedule.min.js: {
       preprocess: false,


### PR DESCRIPTION
For every JS lib that is 1) react lib 2) is not preprocessed, we replace version with HELFI_DEPLOYMENT_IDENTIFIER tag for helfi_api_base module.

Varnish cache clearing on purge removed in [this](https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/pull/80) PR.

# [UHF-10628](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10628)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->
* libraries in hdbt now use  HELFI_DEPLOYMENT_IDENTIFIER instead of static version
* Varnish cache purge was removed from helfi_proxy module

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-10628`
* Add deploy id to `local.settings.php` 
  * For example: `$settings['deployment_identifier'] = 'local-1234';`
* Run `make drush-cr`
* Build theme in the `public/themes/contrib/hdbt`:
  * `nvm use; npm i; npm run build`

## How to test

* [ ] Check that theme builds
* [ ] Check that javascripts work

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* [UHF-10628](https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/pull/80)


[UHF-10628]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ