### PR TITLE
UHF-9754: Fix `tapahtumapaikka` filter

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -1641,9 +1641,10 @@ function hdbt_preprocess_paragraph__event_list(&$variables): void {
     $linkedEvents = \Drupal::service(LinkedEvents::class);
     $settings['use_fixtures'] = $linkedEvents->getFixture();
 
-    /** @var \Symfony\Component\Serializer\SerializerInterface $serializer */
-    $serializer = \Drupal::service('serializer');
-    $settings['places'] = array_map(fn (LinkedEventsItem $item) => $serializer->serialize($item, 'json'), $paragraph->getPlaces());
+    $settings['places'] = array_map(fn (LinkedEventsItem $item) => [
+      "id" => $item->id,
+      "name" => $item->name,
+    ], $paragraph->getPlaces());
 
     $settings += $paragraph->getFilterSettings();
 


### PR DESCRIPTION
# [UHF-9754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Fix: `Tapahtumapaikka` filter does not work on page [palvelukeskusten-ryhmat](https://www.test.hel.ninja/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/tekemista-ja-vertaistukea/palvelukeskukset/palvelukeskusten-ryhmat).

## How to install

* Make sure your sote is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9754`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check `Tapahtumapaikka` filter on page [palvelukeskusten-ryhmat](https://hefi-sote.docker.so/sosiaali-ja-terveyspalvelut/senioripalvelut/tekemista-ja-vertaistukea/palvelukeskukset/palvelukeskusten-ryhmat).
* [ ] Check that code follows our standards