### PR TITLE
UHF-8899: Added check if it should be ol or ul

### DIFF
--- a/templates/paragraphs/paragraph--phasing.html.twig
+++ b/templates/paragraphs/paragraph--phasing.html.twig
@@ -1,4 +1,5 @@
 {% set phasing_title_level = paragraph.getHeadingLevel() %}
+{% set show_numbers = paragraph.getShowNumbers() %}
 
 {% block paragraph %}
   {% embed "@hdbt/misc/component.twig" with
@@ -8,7 +9,7 @@
       component_title_level: phasing_title_level,
       component_description: content.field_description,
       component_content_class: 'phasing',
-      component_content_tag: 'ol',
+      component_content_tag: show_numbers ? 'ol' : 'ul',
     }
   %}
     {% block component_content %}


### PR DESCRIPTION
# [UHF-8899](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8899)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added check to phasing paragraph if wrapping element should be ol or ul

## How to install

Test for example in etusivu

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8899`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-8899`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create a basic page that has two phasing paragraphs, create the other with numbers and the other without
* [ ] Make sure that the one with numbers has `ol` and the one without numbers has `ul`
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/997


[UHF-8899]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ