### PR TITLE
UHF-5038: Added description fields for list of links and content cards

### DIFF
--- a/templates/paragraphs/paragraph--content-cards.html.twig
+++ b/templates/paragraphs/paragraph--content-cards.html.twig
@@ -27,6 +27,7 @@
         ],
         component_koro: has_koro ? { flip: true },
         component_title: title,
+        component_description: content.field_content_cards_desc,
         component_content_class: 'content-cards',
       }
     %}

--- a/templates/paragraphs/paragraph--list-of-links.html.twig
+++ b/templates/paragraphs/paragraph--list-of-links.html.twig
@@ -15,12 +15,13 @@
         design_class,
       ],
       component_title: title,
+      component_description: content.field_list_of_links_description,
       component_content_class: 'list-of-links',
     }
   %}
     {% block component_content %}
 
-      {{ content|without('field_list_of_links_design', 'field_list_of_links_title') }}
+      {{ content|without('field_list_of_links_design', 'field_list_of_links_title', 'field_list_of_links_description') }}
 
     {% endblock component_content %}
   {% endembed %}


### PR DESCRIPTION
# [UHF-5038](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5038)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added description fields for list of links and content cards

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-5038`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] See platform config pr for instructions
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1019
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1306
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1122


[UHF-5038]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ