### PR TITLE
UHF-11580: Removed deprecated fields from contact card template

### DIFF
--- a/templates/paragraphs/paragraph--contact-card.html.twig
+++ b/templates/paragraphs/paragraph--contact-card.html.twig
@@ -9,7 +9,7 @@
 
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
-    <div class="{% if content.field_contact_image|render or content.field_contact_image_reference|render%}contact-card__image-container{% else %}contact-card__color-line{% endif %}">
+    <div class="{% if content.field_contact_image_reference|render%}contact-card__image-container{% else %}contact-card__color-line{% endif %}">
       {% if content.field_contact_image_reference|render %}
         {{ content.field_contact_image_reference }}
       {% endif %}


### PR DESCRIPTION
# [UHF-11580](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11580)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed references to deprecated fields from contact card template

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11580 `
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See platform config pr
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1022



[UHF-11580]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ