### PR TITLE
UHF-8137: Removed role navigation and role contentinfo

### DIFF
--- a/templates/block/block--external-menu-block--header-top-navigation.html.twig
+++ b/templates/block/block--external-menu-block--header-top-navigation.html.twig
@@ -34,7 +34,7 @@
 
 {# Render navigation with content from another instance "globally" #}
 {% if use_global_navigation %}
-  <nav role="navigation" aria-label="{{ 'Quick links'|t({}, {'context': 'Header top navigation screen reader name'}) }}"{{ attributes|without('role', 'aria-labelledby', 'id', 'aria-label') }}>
+  <nav aria-label="{{ 'Quick links'|t({}, {'context': 'Header top navigation screen reader name'}) }}"{{ attributes|without('role', 'aria-labelledby', 'id', 'aria-label') }}>
 
     {# Menu. #}
     {% block content %}

--- a/templates/block/block--external-menu-block.html.twig
+++ b/templates/block/block--external-menu-block.html.twig
@@ -35,7 +35,7 @@
 {# Render navigation with content from another instance "globally" #}
 {% if use_global_navigation %}
   {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-  <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby', 'id') }}>
+  <nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby', 'id') }}>
     {# Label. If not displayed, we still provide it for screen readers. #}
     {% if not configuration.label_display %}
       {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--main-navigation-level-2.html.twig
+++ b/templates/block/block--main-navigation-level-2.html.twig
@@ -46,7 +46,7 @@
 } %}
 
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }} class="sidebar-navigation">
+<nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }} class="sidebar-navigation">
   <div{{ title_attributes.setAttribute('id', heading_id) }} class="sidebar-navigation__title">
     {{ link(link_title, link_url, link_attributes) }}
   </div>

--- a/templates/block/block--mainnavigation--non-core.html.twig
+++ b/templates/block/block--mainnavigation--non-core.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby').setAttribute('data-hdbt-selector','main-navigation') }} class="desktop-menu">
+<nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby').setAttribute('data-hdbt-selector','main-navigation') }} class="desktop-menu">
   <span class="is-hidden" id="{{ heading_id }}">{{ 'Main navigation'|t({}, {'context': 'Aria label for main navigation'}) }}</span>
   {# Menu. #}
   {% block content %}

--- a/templates/block/block--mainnavigation.html.twig
+++ b/templates/block/block--mainnavigation.html.twig
@@ -32,7 +32,7 @@
  */
 #}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby').setAttribute('data-hdbt-selector','main-navigation') }} class="desktop-menu">
+<nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby').setAttribute('data-hdbt-selector','main-navigation') }} class="desktop-menu">
   <span class="is-hidden" id="{{ heading_id }}">{{ 'Main navigation'|t({}, {'context': 'Aria label for main navigation'}) }}</span>
   {# Menu. #}
   {% block content %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -212,7 +212,7 @@
     {% set footer_variant = 'footer--light' %}
   {% endif %}
 
-  <footer role="contentinfo" class="footer {{ footer_variant }}">
+  <footer class="footer {{ footer_variant }}">
     {% include '@hdbt/misc/koro.twig' with { flip: false } %}
     {% if page.footer_top %}
       {{ page.footer_top }}

--- a/templates/misc/nav-toggle-dropdown.twig
+++ b/templates/misc/nav-toggle-dropdown.twig
@@ -2,7 +2,7 @@
 
 {% if description %}
   {% set nav_toggle_dropdown_id = id ~ '-menu'|clean_id %}
-  <nav id="{{ id }}" role="navigation" {{ create_attribute({'class': wrapper_classes}) }} aria-labelledby="{{ nav_toggle_dropdown_id }}">
+  <nav id="{{ id }}" {{ create_attribute({'class': wrapper_classes}) }} aria-labelledby="{{ nav_toggle_dropdown_id }}">
     <span class="is-hidden" id="{{ nav_toggle_dropdown_id }}">{{ description }}</span>
 {% else %}
   <div id="{{ id }}" {{ create_attribute({'class': wrapper_classes}) }}>

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -9,7 +9,7 @@
  */
 #}
 {% if links %}
-  <nav class="hds-breadcrumb" role="navigation" aria-label="{{ 'Breadcrumb'|t }}">
+  <nav class="hds-breadcrumb" aria-label="{{ 'Breadcrumb'|t }}">
     <ol class="hds-breadcrumb__list hds-breadcrumb__list--desktop">
     {% for item in links %}
       <li class="hds-breadcrumb__list-item {% if item.url.toString() is  empty %}hds-breadcrumb__list-item--active{% endif %}">

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -32,7 +32,7 @@
 #}
 {% if items %}
   <div class="hds-pagination-container">
-    <nav class="hds-pagination pager" role="navigation" aria-label="{{ 'Pagination'|t({}, {'context': 'Pagination aria-label'}) }}" data-next="{{ items.next.text|default('Next'|t({}, {'context': 'Pagination next page link text'})) }}">
+    <nav class="hds-pagination pager" aria-label="{{ 'Pagination'|t({}, {'context': 'Pagination aria-label'}) }}" data-next="{{ items.next.text|default('Next'|t({}, {'context': 'Pagination next page link text'})) }}">
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}
         {% set prev_button_classes = [


### PR DESCRIPTION
# [UHF-8137](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8137)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed unnecessary role attributes from footer and navigations

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-8137`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Doesn't really need to be tested but you can make sure footer and the different navigations still work as they did before.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

