### PR TITLE
UHF-12075: use name_override field instead of name if exists

### DIFF
--- a/templates/module/helfi_tpr/tpr-errand-service.html.twig
+++ b/templates/module/helfi_tpr/tpr-errand-service.html.twig
@@ -21,7 +21,11 @@
 
       <div{{ content_attributes.addClass('errand-service__header') }}>
         <h2{{ title_attributes.addClass('errand-service__title') }}>
-          {{ content.name }}
+          {% if content.name_override %}
+            {{ content.name_override }}
+          {% else %}
+            {{ content.name }}
+          {% endif %}
         </h2>
       </div>
 


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-0000_insert_correct_branch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
