### PR TITLE
UHF-12025: Added status tag to news page

### DIFF
--- a/templates/content/node--news-item.html.twig
+++ b/templates/content/node--news-item.html.twig
@@ -18,7 +18,7 @@
         {% block content %}
           {% include '@hdbt/misc/tag.twig' with {
             tag: tag_content,
-            color: 'alert'
+            type: 'alert',
           }%}
           {% endblock content %}
       {% endembed %}

--- a/templates/misc/tag.twig
+++ b/templates/misc/tag.twig
@@ -4,12 +4,15 @@
   {% if color %}
     {% set tag_color_class = 'content-tags__tags__tag--' ~ color %}
   {% endif %}
+  {% if type %}
+    {% set type_class = 'hds-tag--' ~ type %}
+  {% endif %}
 
   <li class="content-tags__tags__tag">
     {% if addSpan %}
-      <span class="hds-tag {{ tag_color_class }}">{{ tag }}</span>
+      <span class="hds-tag {{ tag_color_class }} {{ type_class }}">{{ tag }}</span>
     {% else %}
-      <div class="hds-tag {{ tag_color_class }}">{{ tag }}</div>
+      <div class="hds-tag {{ tag_color_class }} {{ type_class }}">{{ tag }}</div>
     {% endif %}
   </li>
 {% endif %}


### PR DESCRIPTION
# [UHF-12025](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12025)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added status tag to news article

## How to install

* Make sure your **ETUSIVU** instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-12025-news-tag`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x]  Go here https://helfi-etusivu.docker.so/fi/uutiset/kannelmaen-terveysaseman-palvelujen-uusi-tuottaja-on-valittu and make sure the tag has the icon and is yellow
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-12025]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ