### PR TITLE
UHF-13051: Revert the cookie banner changes, will be reimplemented later

### DIFF
--- a/src/js/matomo.js
+++ b/src/js/matomo.js
@@ -9,14 +9,6 @@ function getBrowserSize() {
     const { helfi_environment: environment } = drupalSettings;
 
     if (!(Drupal.cookieConsent.getConsentStatus(['statistics']) && drupalSettings.matomo_site_id)) {
-      // #UHF-13051 Allow catching referrer-header from visitors who accept cookies for the first time.
-      window.addEventListener(
-        'hds-cookie-consent-changed',
-        () => {
-          Drupal.cookieConsent.loadFunction(loadMatomoAnalytics);
-        },
-        { once: true },
-      );
       return;
     }
     const getViewportWidth = () => window.innerWidth;


### PR DESCRIPTION
This change enabled matomo once user had accepted cookies. Will be reimplemented later