### PR TITLE
UHF-13138: No results text for the recommendations block

### DIFF
--- a/templates/module/helfi_recommendations/recommendations-block.html.twig
+++ b/templates/module/helfi_recommendations/recommendations-block.html.twig
@@ -5,64 +5,68 @@
 {% endif %}
 
 {% if rows is not empty %}
-  <div class="components components--computed components--recommendations">
-    {% block paragraph %}
-      {% embed "@hdbt/misc/component.twig" with
-        {
-          component_classes: [ 'component', 'component--recommendations', tiny_cards ? 'component--recommendations--tiny-cards' : '', 'component--hardcoded', 'component--full-width', 'hide-from-table-of-contents' ],
-          component_title: 'Recommended for you'|t({}, {'context': 'Recommendations block title'}),
-          component_description: 'Recommendations are generated automatically based on content.'|t({}, {'context': 'Recommendations block description'}),
-          use_component_title_lang_fallback: alternative_language ?? false,
-        }
-      %}
-        {% block component_content %}
-          {% for row in rows %}
-            {% if row.published_at %}
-              {% set html_published_at  %}
-                <time datetime="{{ row.published_at|format_date('custom', 'Y-m-d\\TH:i') }}" class="news-listing__datetime news-listing__datetime--published" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
-                  {{ row.published_at|format_date('publication_date_format') }}
-                </time>
-              {% endset %}
-            {% endif %}
-
-            {% if tiny_cards %}
-              {% set published_information %}
-                {{ 'News'|t({}, {'context': 'Label for tiny news card content type'}) }}{{ html_published_at }}
-              {% endset %}
-              {% embed '@hdbt/component/card.twig' with {
-                card_modifier_class: 'card--tiny',
-                card_title: row.title,
-                card_title_level: 'div',
-                card_url: row.url,
-                card_helptext: row.helptext,
-                card_metas: row.published_at ? [
-                  {
-                    content: published_information
-                  },
-                ] : [],
-              } %}
-              {% endembed %}
-            {% else %}
-              {% embed '@hdbt/component/card.twig' with {
-                card_image: row.image,
-                card_title: row.title,
-                card_title_level: 'h3',
-                card_url: row.url,
-                card_helptext: row.helptext,
-                card_metas: row.published_at ? [
-                  {
-                    icon: 'clock',
-                    label: 'Published'|t({}, {'context': 'Label for news card published time'}),
-                    content: html_published_at
-                  },
-                ] : [],
-              } %}
-              {% endembed %}
-            {% endif %}
-
-          {% endfor %}
-        {% endblock component_content %}
-      {% endembed %}
-    {% endblock paragraph %}
-  </div>
+  {% set component_description = 'Recommendations are generated automatically based on content.'|t({}, {'context': 'Recommendations block description'}) %}
+{% else %}
+  {% set component_description = no_results_message %}
 {% endif %}
+
+<div class="components components--computed components--recommendations">
+  {% block paragraph %}
+    {% embed "@hdbt/misc/component.twig" with
+      {
+        component_classes: [ 'component', 'component--recommendations', tiny_cards ? 'component--recommendations--tiny-cards' : '', 'component--hardcoded', 'component--full-width', 'hide-from-table-of-contents' ],
+        component_title: 'Recommended for you'|t({}, {'context': 'Recommendations block title'}),
+        component_description: component_description,
+        use_component_title_lang_fallback: alternative_language ?? false,
+      }
+    %}
+      {% block component_content %}
+        {% for row in rows %}
+          {% if row.published_at %}
+            {% set html_published_at  %}
+              <time datetime="{{ row.published_at|format_date('custom', 'Y-m-d\\TH:i') }}" class="news-listing__datetime news-listing__datetime--published" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+                {{ row.published_at|format_date('publication_date_format') }}
+              </time>
+            {% endset %}
+          {% endif %}
+
+          {% if tiny_cards %}
+            {% set published_information %}
+              {{ 'News'|t({}, {'context': 'Label for tiny news card content type'}) }}{{ html_published_at }}
+            {% endset %}
+            {% embed '@hdbt/component/card.twig' with {
+              card_modifier_class: 'card--tiny',
+              card_title: row.title,
+              card_title_level: 'div',
+              card_url: row.url,
+              card_helptext: row.helptext,
+              card_metas: row.published_at ? [
+                {
+                  content: published_information
+                },
+              ] : [],
+            } %}
+            {% endembed %}
+          {% else %}
+            {% embed '@hdbt/component/card.twig' with {
+              card_image: row.image,
+              card_title: row.title,
+              card_title_level: 'h3',
+              card_url: row.url,
+              card_helptext: row.helptext,
+              card_metas: row.published_at ? [
+                {
+                  icon: 'clock',
+                  label: 'Published'|t({}, {'context': 'Label for news card published time'}),
+                  content: html_published_at
+                },
+              ] : [],
+            } %}
+            {% endembed %}
+          {% endif %}
+
+        {% endfor %}
+      {% endblock component_content %}
+    {% endembed %}
+  {% endblock paragraph %}
+</div>

--- a/templates/module/helfi_recommendations/recommendations-block.html.twig
+++ b/templates/module/helfi_recommendations/recommendations-block.html.twig
@@ -10,8 +10,69 @@
   {% set component_description = no_results_message %}
 {% endif %}
 
-<div class="components components--computed components--recommendations">
-  {% block paragraph %}
+{% if rows is not empty %}
+  <div class="components components--computed components--recommendations">
+    {% block paragraph %}
+      {% embed "@hdbt/misc/component.twig" with
+        {
+          component_classes: [ 'component', 'component--recommendations', tiny_cards ? 'component--recommendations--tiny-cards' : '', 'component--hardcoded', 'component--full-width', 'hide-from-table-of-contents' ],
+          component_title: 'Recommended for you'|t({}, {'context': 'Recommendations block title'}),
+          component_description: component_description,
+          use_component_title_lang_fallback: alternative_language ?? false,
+        }
+      %}
+        {% block component_content %}
+          {% for row in rows %}
+            {% if row.published_at %}
+              {% set html_published_at  %}
+                <time datetime="{{ row.published_at|format_date('custom', 'Y-m-d\\TH:i') }}" class="news-listing__datetime news-listing__datetime--published" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+                  {{ row.published_at|format_date('publication_date_format') }}
+                </time>
+              {% endset %}
+            {% endif %}
+
+            {% if tiny_cards %}
+              {% set published_information %}
+                {{ 'News'|t({}, {'context': 'Label for tiny news card content type'}) }}{{ html_published_at }}
+              {% endset %}
+              {% embed '@hdbt/component/card.twig' with {
+                card_modifier_class: 'card--tiny',
+                card_title: row.title,
+                card_title_level: 'div',
+                card_url: row.url,
+                card_helptext: row.helptext,
+                card_metas: row.published_at ? [
+                  {
+                    content: published_information
+                  },
+                ] : [],
+              } %}
+              {% endembed %}
+            {% else %}
+              {% embed '@hdbt/component/card.twig' with {
+                card_image: row.image,
+                card_title: row.title,
+                card_title_level: 'h3',
+                card_url: row.url,
+                card_helptext: row.helptext,
+                card_metas: row.published_at ? [
+                  {
+                    icon: 'clock',
+                    label: 'Published'|t({}, {'context': 'Label for news card published time'}),
+                    content: html_published_at
+                  },
+                ] : [],
+              } %}
+              {% endembed %}
+            {% endif %}
+
+          {% endfor %}
+        {% endblock component_content %}
+      {% endembed %}
+    {% endblock paragraph %}
+  </div>
+{% elseif no_results_message is not empty %}
+  <div class="components components--computed components--recommendations">
     {% embed "@hdbt/misc/component.twig" with
       {
         component_classes: [ 'component', 'component--recommendations', tiny_cards ? 'component--recommendations--tiny-cards' : '', 'component--hardcoded', 'component--full-width', 'hide-from-table-of-contents' ],
@@ -20,53 +81,6 @@
         use_component_title_lang_fallback: alternative_language ?? false,
       }
     %}
-      {% block component_content %}
-        {% for row in rows %}
-          {% if row.published_at %}
-            {% set html_published_at  %}
-              <time datetime="{{ row.published_at|format_date('custom', 'Y-m-d\\TH:i') }}" class="news-listing__datetime news-listing__datetime--published" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
-                {{ row.published_at|format_date('publication_date_format') }}
-              </time>
-            {% endset %}
-          {% endif %}
-
-          {% if tiny_cards %}
-            {% set published_information %}
-              {{ 'News'|t({}, {'context': 'Label for tiny news card content type'}) }}{{ html_published_at }}
-            {% endset %}
-            {% embed '@hdbt/component/card.twig' with {
-              card_modifier_class: 'card--tiny',
-              card_title: row.title,
-              card_title_level: 'div',
-              card_url: row.url,
-              card_helptext: row.helptext,
-              card_metas: row.published_at ? [
-                {
-                  content: published_information
-                },
-              ] : [],
-            } %}
-            {% endembed %}
-          {% else %}
-            {% embed '@hdbt/component/card.twig' with {
-              card_image: row.image,
-              card_title: row.title,
-              card_title_level: 'h3',
-              card_url: row.url,
-              card_helptext: row.helptext,
-              card_metas: row.published_at ? [
-                {
-                  icon: 'clock',
-                  label: 'Published'|t({}, {'context': 'Label for news card published time'}),
-                  content: html_published_at
-                },
-              ] : [],
-            } %}
-            {% endembed %}
-          {% endif %}
-
-        {% endfor %}
-      {% endblock component_content %}
     {% endembed %}
-  {% endblock paragraph %}
-</div>
+  </div>
+{% endif %}


### PR DESCRIPTION
# [UHF-13138](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13138)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Added no results text which is shown to a logged in user.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/helfi_platform_config:dev-UHF-13138 drupal/hdbt:dev-UHF-13138 -W`
* Run code updates
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Setup the etusivu and check that the recommendations block works as before: https://helfi-etusivu.docker.so/fi/uutiset/kapylan-liikuntapuistoon-koti-myos-tapahtumille
* [ ] Check that the code follows our standards
* [ ] Check that the differences in visual regression tests are appropriate


[UHF-13138]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ