### PR TITLE
UHF-11768: Make sure login block contains url.path cache context

### DIFF
--- a/templates/layout/page--401.html.twig
+++ b/templates/layout/page--401.html.twig
@@ -29,7 +29,7 @@
           {% endif %}
           {{ optional_login_block_description }}
           <div class="error-page__login-form">
-            {{ drupal_block('user_login_block') }}
+            {{ drupal_block('user_login_block')|with('#cache', {contexts: ['url.path'] }) }}
           </div>
         </div>
         {% embed '@hdbt/misc/special-page-illustration.twig' with {


### PR DESCRIPTION
# [UHF-11768](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11768)

## What was done

* Changed the login form block to be cached per page. This should fix the issue where `form_state` uses a cached destination from another page.

## How to install

* Update the HDBT theme:

  * `composer require drupal/hdbt:dev-UHF-UHF-11768`

## How to test

* [x] Flush caches (`drush cr`)
* [x] As an anonymous user, open `/user/1`
* [x] As an anonymous user, open your own user page, for example `/user/321`
* [x] Log in using your own account
* [x] Verify that you are redirected to your own user page (`/user/321`)

[UHF-11768]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ