### PR TITLE
UHF-13272: Fix issue with logged in user search boxes linking to wrong environment

### DIFF
--- a/hdbt.theme
+++ b/hdbt.theme
@@ -192,9 +192,9 @@ function hdbt_get_global_url(string $langcode): array {
 }
 
 /**
- * Resolves the AI assisted search form URL for the given language via EnvironmentResolver.
+ * Resolves the AI assisted search form URL for the given language.
  *
- * Falls back to $fallback if the environment cannot be determined.
+ * Uses EnvironmentResolver; falls back to $fallback on failure.
  */
 function _hdbt_resolve_ai_search_form_url(string $langcode, string $fallback): string {
   /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $resolver */

--- a/hdbt.theme
+++ b/hdbt.theme
@@ -192,6 +192,24 @@ function hdbt_get_global_url(string $langcode): array {
 }
 
 /**
+ * Resolves the AI assisted search form URL for the given language via EnvironmentResolver.
+ *
+ * Falls back to $fallback if the environment cannot be determined.
+ */
+function _hdbt_resolve_ai_search_form_url(string $langcode, string $fallback): string {
+  /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $resolver */
+  $resolver = \Drupal::service('helfi_api_base.environment_resolver');
+  try {
+    $activeEnvironment = $resolver->getActiveEnvironment()->getEnvironmentName();
+    $etusivu = $resolver->getEnvironment(Project::ETUSIVU, $activeEnvironment);
+    return $etusivu->getUrl($langcode) . '/search/new';
+  }
+  catch (\Exception) {
+    return $fallback;
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_preprocess_page(&$variables): void {
@@ -220,6 +238,10 @@ function hdbt_preprocess_page(&$variables): void {
     $variables[$key] = $value;
   }
   $variables['help_text_link_url'] = Url::fromUri($variables['ai_register_url']);
+  $variables['helfi_ai_search_form_url'] = _hdbt_resolve_ai_search_form_url(
+    $variables['language']->getId(),
+    $variables['helfi_ai_search_form_url'],
+  );
 
   // Toggle between global and local navigation in twig templates.
   $variables['use_global_navigation'] = _hdbt_use_global_navigation();
@@ -835,7 +857,10 @@ function hdbt_preprocess_paragraph__hero(&$variables) {
   ) {
     $search_urls = hdbt_get_global_url($variables['language']->getId());
     $variables['helfi_search_form_url'] = $search_urls['helfi_search_form_url'];
-    $variables['helfi_ai_search_form_url'] = $search_urls['helfi_ai_search_form_url'];
+    $variables['helfi_ai_search_form_url'] = _hdbt_resolve_ai_search_form_url(
+      $variables['language']->getId(),
+      $search_urls['helfi_ai_search_form_url'],
+    );
 
     // Cache separately for logged-in and anonymous users so the correct
     // search form variant is rendered.


### PR DESCRIPTION
# [UHF-13272](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13272)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fix issue with all environments linking to local instead of the correct environment from the search blocks.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your etusivu instance and some other instance like sote is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-13272`
* Update the Helfi API Base module
  * `composer require drupal/helfi_api_base:dev-UHF-13272`
* Run code updates
  * `make drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Make sure that the hero and header blocks still work correctly on local. This PR should fix issue with blocks trying to link to local from testing environment.
* [ ] Check that the code follows our standards.
* [ ] Check that the differences in visual regression tests are appropriate.

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1622
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/277


[UHF-13272]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ